### PR TITLE
Fix headless Cursor Fix on a stale clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `xdlc doctor --skip-network` warns (does not fail) when every repo has a local `dir:` and GitHub auth is unset.
 - A Fix's recorded `total_cost_usd` / token counts are now the sum of every agent run it took, not just the last one. Previously an `agent.fix_plan` Fix reported only its patch pass, hiding the diagnose pass it also paid for.
 - Evidence values containing spaces (an agent summary, a fleet escalation reason) are quoted in `BACKLOG.md` and the console Activity row, so a free-text value no longer reads as the start of the next `key=`. Both now use one formatter.
+- `EnsureCloned` skip-fetch compares HEAD to `git ls-remote`, not the local `origin/<branch>` tracking ref. A clone that had not fetched since the failing push used to skip onto the previous (green) commit, so Fix never saw the break.
+- Cursor CLI defaults include `--force` (with `--trust`). `--trust` only skips the workspace prompt. Without `--force`, a headless Fix gets `userRejected` on unallowlisted shell commands and never opens a PR.
 
 ### Changed
 
@@ -58,8 +60,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Subagent: prompt on stdin (not argv); kill process group on timeout; external gates get env allowlist + same kill hygiene (#11)
-- `EnsureCloned`: skip fetch when HEAD matches `origin/<branch>` and tree clean; shallow first clone; parallel startup pre-clone (#17)
-- Cursor CLI defaults: `-p --trust` for headless/demo workdirs
+- `EnsureCloned`: skip fetch when HEAD matches the remote tip (`ls-remote`) and the tree is clean; shallow first clone; parallel startup pre-clone (#17)
+- Cursor CLI defaults: `-p --trust --force` for headless Fix (workspace trust plus auto-approved tools)
 - Actions: Manual Fix/Promote/Revert post config repo `id` (not GitHub slug)
 - Console `/repos/$id`: parent layout uses `<Outlet />` so timeline renders (was stuck on list)
 

--- a/internal/repos/manager.go
+++ b/internal/repos/manager.go
@@ -249,10 +249,13 @@ func AuthEnv(token string) []string {
 
 // EnsureCloned makes dir a clean checkout of repo's branch: clones it if
 // the directory doesn't exist, or fetches + hard-resets it to
-// origin/<branch> if it does. When HEAD already matches origin/<branch>
-// and the working tree is clean, the network fetch is skipped (issue #17).
-// The hard reset still runs when dirty or diverged — a plain `git fetch`
-// alone would leave the working tree on a stale commit.
+// origin/<branch> if it does. When HEAD already matches the remote tip
+// (ls-remote, not the local origin/<branch> tracking ref) and the
+// working tree is clean, the fetch is skipped (issue #17). Comparing
+// only the tracking ref would skip a Fix onto a stale commit after a
+// push the clone has not fetched yet. The hard reset still runs when
+// dirty or diverged: a plain `git fetch` alone would leave the working
+// tree on a stale commit.
 func (m *Manager) EnsureCloned(ctx context.Context, repo string) error {
 	r, ok := m.repos[repo]
 	if !ok {
@@ -264,7 +267,7 @@ func (m *Manager) EnsureCloned(ctx context.Context, repo string) error {
 	env := m.AuthEnv()
 
 	if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
-		if synced, _ := localMatchesOrigin(ctx, dir, branch); synced {
+		if m.localMatchesRemote(ctx, repo, dir, branch) {
 			return nil
 		}
 		if err := runGit(ctx, dir, env, "fetch", "origin", branch); err != nil {
@@ -283,26 +286,28 @@ func (m *Manager) EnsureCloned(ctx context.Context, repo string) error {
 	return runGit(ctx, "", env, "clone", "--depth", "1", "--single-branch", "--branch", branch, url, dir)
 }
 
-// localMatchesOrigin is true when HEAD is on branch, equals
-// origin/<branch>, and the working tree is clean — no network needed.
-func localMatchesOrigin(ctx context.Context, dir, branch string) (bool, error) {
+// localMatchesRemote is true when HEAD is on branch, the tree is clean,
+// and HEAD equals the remote tip from ls-remote. A matching local
+// origin/<branch> tracking ref is not enough: that ref is only as fresh
+// as the last fetch.
+func (m *Manager) localMatchesRemote(ctx context.Context, repo, dir, branch string) bool {
 	cur, err := gitOutput(ctx, dir, "rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil || cur != branch {
-		return false, err
-	}
-	head, err := gitOutput(ctx, dir, "rev-parse", "HEAD")
-	if err != nil {
-		return false, err
-	}
-	origin, err := gitOutput(ctx, dir, "rev-parse", "origin/"+branch)
-	if err != nil || head != origin {
-		return false, err
+		return false
 	}
 	status, err := gitOutput(ctx, dir, "status", "--porcelain")
 	if err != nil || status != "" {
-		return false, err
+		return false
 	}
-	return true, nil
+	head, err := gitOutput(ctx, dir, "rev-parse", "HEAD")
+	if err != nil {
+		return false
+	}
+	remote, err := m.RemoteSHA(ctx, repo)
+	if err != nil || head != remote {
+		return false
+	}
+	return true
 }
 
 func gitOutput(ctx context.Context, dir string, args ...string) (string, error) {

--- a/internal/repos/manager_test.go
+++ b/internal/repos/manager_test.go
@@ -263,3 +263,64 @@ func TestEnsureClonedSkipsFetchWhenSynced(t *testing.T) {
 		t.Errorf("FETCH_HEAD mtime changed (%v → %v); expected skip-fetch no-op", before.ModTime(), after.ModTime())
 	}
 }
+
+// TestEnsureClonedFetchesWhenTrackingRefStale is the snackytalky
+// regression: HEAD equals the local origin/<branch> tracking ref, so the
+// old skip-fetch path thought the clone was current, while origin had
+// moved. A Fix then edited the previous (green) commit.
+func TestEnsureClonedFetchesWhenTrackingRefStale(t *testing.T) {
+	root := t.TempDir()
+	bareDir := filepath.Join(root, "origin.git")
+	seedDir := filepath.Join(root, "seed")
+	workDir := filepath.Join(root, "work")
+
+	gitCmdTest(t, root, "init", "--bare", bareDir)
+	gitCmdTest(t, root, "clone", bareDir, seedDir)
+	gitCmdTest(t, seedDir, "config", "user.email", "test@example.com")
+	gitCmdTest(t, seedDir, "config", "user.name", "test")
+	gitCmdTest(t, seedDir, "checkout", "-b", "develop")
+	if err := os.WriteFile(filepath.Join(seedDir, "app.txt"), []byte("v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmdTest(t, seedDir, "add", ".")
+	gitCmdTest(t, seedDir, "commit", "-m", "v1")
+	gitCmdTest(t, seedDir, "push", "origin", "develop")
+	gitCmdTest(t, bareDir, "symbolic-ref", "HEAD", "refs/heads/develop")
+	gitCmdTest(t, root, "clone", "--branch", "develop", bareDir, workDir)
+
+	if err := os.WriteFile(filepath.Join(seedDir, "app.txt"), []byte("v2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmdTest(t, seedDir, "add", ".")
+	gitCmdTest(t, seedDir, "commit", "-m", "v2")
+	gitCmdTest(t, seedDir, "push", "origin", "develop")
+
+	local := strings.TrimSpace(gitCmdTest(t, workDir, "rev-parse", "HEAD"))
+	tracking := strings.TrimSpace(gitCmdTest(t, workDir, "rev-parse", "origin/develop"))
+	if local != tracking {
+		t.Fatalf("precondition: HEAD %s != origin/develop %s", local, tracking)
+	}
+	want := strings.TrimSpace(gitCmdTest(t, bareDir, "rev-parse", "develop"))
+	if local == want {
+		t.Fatal("precondition: clone already has origin's new tip")
+	}
+
+	mgr := NewManager("unused-root", []config.Repo{
+		{Name: "svc", GitHub: "org/svc", Dir: workDir, Branch: "develop"},
+	}, nil)
+	if err := mgr.EnsureCloned(context.Background(), "svc"); err != nil {
+		t.Fatalf("EnsureCloned: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(workDir, "app.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(got)) != "v2" {
+		t.Errorf("app.txt = %q after EnsureCloned, want v2 (origin moved, tracking ref was stale)", got)
+	}
+	head := strings.TrimSpace(gitCmdTest(t, workDir, "rev-parse", "HEAD"))
+	if head != want {
+		t.Errorf("HEAD %s != origin develop %s", head, want)
+	}
+}

--- a/internal/subagent/runner.go
+++ b/internal/subagent/runner.go
@@ -143,14 +143,17 @@ var providerDefaults = map[Provider]providerSpec{
 	},
 	ProviderCursor: {
 		binary: "cursor-agent",
-		// -p print/non-interactive; --trust required for temp/demo workdirs
-		args: []string{"-p", "--trust", promptPlaceholder},
+		// -p print/non-interactive. --trust skips the workspace prompt.
+		// --force (alias --yolo) auto-approves file/shell tools; --trust
+		// alone still blocks unallowlisted commands as userRejected, and
+		// a headless Fix has no TTY to answer them.
+		args: []string{"-p", "--trust", "--force", promptPlaceholder},
 	},
 	ProviderGemini: {
 		binary: "gemini",
 		// -p headless prompt; --yolo auto-approves the file/shell tool
 		// calls a Fix needs (the CLI otherwise waits on a TTY prompt that
-		// never comes). Same tradeoff as cursor's --trust.
+		// never comes). Same tradeoff as cursor's --force.
 		args: []string{"-p", promptPlaceholder, "--yolo"},
 	},
 }

--- a/internal/subagent/runner_test.go
+++ b/internal/subagent/runner_test.go
@@ -18,7 +18,7 @@ func TestNewSubprocessRunnerProviderDefaults(t *testing.T) {
 	}{
 		{ProviderClaude, "claude", []string{"-p", promptPlaceholder, "--output-format", "json"}},
 		{ProviderCodex, "codex", []string{"exec", promptPlaceholder}},
-		{ProviderCursor, "cursor-agent", []string{"-p", "--trust", promptPlaceholder}},
+		{ProviderCursor, "cursor-agent", []string{"-p", "--trust", "--force", promptPlaceholder}},
 		{"some-unknown-future-provider", "claude", []string{"-p", promptPlaceholder, "--output-format", "json"}},
 	}
 
@@ -188,6 +188,21 @@ func TestExtractEnvWithExtraKeys(t *testing.T) {
 	// nil extras behaves exactly like ExtractAllowlistEnv.
 	if strings.Join(ExtractEnv(in, nil), "\n") != strings.Join(ExtractAllowlistEnv(in), "\n") {
 		t.Error("ExtractEnv(in, nil) should match ExtractAllowlistEnv(in)")
+	}
+}
+
+func TestCursorProviderDefaults(t *testing.T) {
+	r := NewSubprocessRunner(ProviderCursor, "", nil, 0, nil)
+	if r.Binary != "cursor-agent" {
+		t.Fatalf("want cursor-agent binary, got %q", r.Binary)
+	}
+	if !slices.Contains(r.Args, "--trust") {
+		t.Fatalf("want --trust in argv, got %v", r.Args)
+	}
+	// --force auto-approves tool calls; --trust only skips the workspace
+	// prompt. Without --force a headless Fix gets userRejected on shell.
+	if !slices.Contains(r.Args, "--force") {
+		t.Fatalf("want --force in argv, got %v", r.Args)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `EnsureCloned` skip-fetch now compares HEAD to `git ls-remote`, not the local `origin/<branch>` tracking ref, so a Fix sees the failing commit.
- Cursor CLI defaults add `--force` next to `--trust`. `--trust` alone still blocked unallowlisted shell tools as `userRejected` in a headless Fix.

Found while dogfooding CI Fix against snackytalky on Ubuntu.

## Test plan
- [x] `go test ./internal/repos ./internal/subagent` for the new cases (macOS still skips `/proc` in an unrelated existing test)
- [x] `gofmt` clean on touched files
- [ ] CI `make test` / `make lint` on this PR
- [ ] After merge, tag `v0.0.1-beta.3` and install that binary on the Ubuntu host, then replay the failed CI webhook