### PR TITLE
Fix nested worktrees and duplicate Fix PRs for the same SHA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- Per-Fix worktree paths are absolute. `git worktree add` of a relative `repos/.worktrees/...` path was resolved against the clone, so the checkout landed inside the repo and the agent `chdir` missed it (`fork/exec ... no such file or directory`).
+- Per-Fix worktree paths are absolute, and a checkout that would land inside the clone is refused. `git worktree add` of a relative `repos/.worktrees/...` path was resolved against the clone, so the agent `chdir` missed it (`fork/exec ... no such file or directory`).
+- One Fix per repo+SHA after a successful run. A flake-ladder `workflow_run` for the same commit no longer opens a second PR. A failed Fix can still retry. Manual Fix (empty SHA) is unchanged.
+
+### Added
+
+- Optional `gates.ci.workflows` allowlist (name, path, or basename such as `ci`). Empty keeps today's behavior: every `workflow_run` on the tracked branch is CI, including Deploy.
 
 ## [0.0.1-beta.3] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Per-Fix worktree paths are absolute. `git worktree add` of a relative `repos/.worktrees/...` path was resolved against the clone, so the checkout landed inside the repo and the agent `chdir` missed it (`fork/exec ... no such file or directory`).
+
 ## [0.0.1-beta.3] - 2026-09-07
 
 ### Fixed

--- a/cmd/xdlc-agent/main.go
+++ b/cmd/xdlc-agent/main.go
@@ -358,6 +358,7 @@ func daemonCmd() *cobra.Command {
 				// CI deliveries (one resolver, shared with promote/revert).
 				BranchFor:     repoMgr.Branch,
 				DefaultBranch: repos.DefaultBranch,
+				CIWorkflows:   cfg.Gates.CI.Workflows,
 				ResolveRepo:   repoMgr.Resolve,
 				// An ArgoCD notification is a check-now trigger: the
 				// verdict comes from the real gate, pinned to the dev tip

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -33,6 +33,7 @@ server:
 gates:
   ci:
     trigger: on_push
+    # workflows: [ci]  # optional. Empty = every workflow_run on the branch.
 
 agent:
   mode: subprocess

--- a/deploy/helm/xdlc-agent/values.yaml
+++ b/deploy/helm/xdlc-agent/values.yaml
@@ -42,6 +42,7 @@ config: |
   gates:
     ci:
       trigger: on_push
+      # workflows: [ci]  # optional. Empty = every workflow_run on the branch.
   server:
     addr: ":8080"
     require_webhook_secret: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -194,6 +194,10 @@ type ExternalGateConfig struct {
 // CIGateConfig configures the ci gate.
 type CIGateConfig struct {
 	Trigger string `yaml:"trigger"`
+	// Workflows is an allowlist of GitHub Actions workflow names or
+	// file basenames (ci, ci.yml, .github/workflows/ci.yml). Empty means
+	// every workflow_run on the tracked branch is CI, including Deploy.
+	Workflows []string `yaml:"workflows"`
 }
 
 // DevSmokeGateConfig configures the dev-smoke gate's shared defaults —

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -27,6 +27,7 @@ server:
 gates:
   ci:
     trigger: on_push
+    workflows: [ci]
   dev-smoke:
     trigger: on_sync
     namespace: dev
@@ -81,6 +82,9 @@ fleet:
 	}
 	if cfg.Server.WebhookRateBurst != 30 {
 		t.Errorf("webhook_rate_burst = %d, want 30", cfg.Server.WebhookRateBurst)
+	}
+	if got := cfg.Gates.CI.Workflows; len(got) != 1 || got[0] != "ci" {
+		t.Errorf("gates.ci.workflows = %v, want [ci]", got)
 	}
 	if cfg.Gates.DevSmoke.Interval != 45*time.Second {
 		t.Errorf("dev-smoke.interval = %v", cfg.Gates.DevSmoke.Interval)

--- a/internal/orchestrator/loop.go
+++ b/internal/orchestrator/loop.go
@@ -57,6 +57,14 @@ type Orchestrator struct {
 	reranMu sync.Mutex
 	reran   map[string]struct{}
 
+	// fixSHA is one successful Fix per repo+SHA this process lifetime.
+	// A flake-ladder rerun of the same commit used to open a second PR
+	// after the first Fix already succeeded. Empty SHA (manual Fix) is
+	// never claimed. A failed Fix clears inflight so a later delivery
+	// can retry.
+	fixSHAMu sync.Mutex
+	fixSHA   map[string]fixSHAState
+
 	// Fleet policy (optional; zero Fleet = no suppressions).
 	Fleet    FleetPolicy
 	RepoDeps map[string][]string // short name → depends_on
@@ -88,7 +96,13 @@ func New(dispatcher Dispatcher, bl *backlog.Store, log *slog.Logger) *Orchestrat
 		breach:     map[string]bool{},
 		RepoDeps:   map[string][]string{},
 		reran:      map[string]struct{}{},
+		fixSHA:     map[string]fixSHAState{},
 	}
+}
+
+type fixSHAState struct {
+	inflight bool
+	ok       bool
 }
 
 // Run blocks, processing signals until ctx is cancelled. Fan-out is by
@@ -187,8 +201,17 @@ func (o *Orchestrator) handle(ctx context.Context, s Signal) {
 			s.Evidence["rerun"] = "success"
 			err = nil
 			_ = green
+		} else if skip := o.claimFixSHA(s); skip != "" {
+			action = ActionNoop
+			if s.Evidence == nil {
+				s.Evidence = map[string]any{}
+			}
+			s.Evidence["skip_fix_sha"] = skip
+			o.Log.Info("skipping duplicate Fix for SHA",
+				"repo", s.Repo, "sha", s.SHA, "reason", skip)
 		} else {
 			err = o.Dispatcher.Fix(ctx, s)
+			o.finishFixSHA(s, err)
 		}
 	case ActionRevert:
 		err = o.Dispatcher.Revert(ctx, s)
@@ -306,4 +329,52 @@ func (o *Orchestrator) tryCIRerun(ctx context.Context, s *Signal) (green bool, s
 	}
 	o.Log.Info("ci rerun still red; invoking Fix", "repo", s.Repo, "run_url", runURL)
 	return false, false
+}
+
+func fixSHAKey(repo, sha string) string {
+	return repo + "\x00" + sha
+}
+
+// claimFixSHA returns a skip reason when this repo+SHA already has a
+// running or successful Fix. Empty SHA is never claimed (manual Fix).
+func (o *Orchestrator) claimFixSHA(s Signal) string {
+	sha := strings.TrimSpace(s.SHA)
+	if sha == "" {
+		return ""
+	}
+	key := fixSHAKey(s.Repo, sha)
+	o.fixSHAMu.Lock()
+	defer o.fixSHAMu.Unlock()
+	if o.fixSHA == nil {
+		o.fixSHA = map[string]fixSHAState{}
+	}
+	st := o.fixSHA[key]
+	if st.inflight {
+		return "inflight"
+	}
+	if st.ok {
+		return "already_fixed"
+	}
+	st.inflight = true
+	o.fixSHA[key] = st
+	return ""
+}
+
+func (o *Orchestrator) finishFixSHA(s Signal, err error) {
+	sha := strings.TrimSpace(s.SHA)
+	if sha == "" {
+		return
+	}
+	key := fixSHAKey(s.Repo, sha)
+	o.fixSHAMu.Lock()
+	defer o.fixSHAMu.Unlock()
+	if o.fixSHA == nil {
+		return
+	}
+	st := o.fixSHA[key]
+	st.inflight = false
+	if err == nil {
+		st.ok = true
+	}
+	o.fixSHA[key] = st
 }

--- a/internal/orchestrator/loop_test.go
+++ b/internal/orchestrator/loop_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"path/filepath"
@@ -227,4 +228,79 @@ func TestFixCoalesceLatestWins(t *testing.T) {
 	if n := disp.fixes(); n > 3 {
 		t.Fatalf("20 CI fails coalesced to %d Fixes; want ≤3", n)
 	}
+}
+
+type scriptedFixDispatcher struct {
+	mu        sync.Mutex
+	calls     int
+	failUntil int
+}
+
+func (d *scriptedFixDispatcher) Fix(context.Context, Signal) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.calls++
+	if d.calls <= d.failUntil {
+		return errors.New("fix failed")
+	}
+	return nil
+}
+func (d *scriptedFixDispatcher) Revert(context.Context, Signal) error  { return nil }
+func (d *scriptedFixDispatcher) Promote(context.Context, Signal) error { return nil }
+func (d *scriptedFixDispatcher) n() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.calls
+}
+
+func TestFixOnePerRepoSHA(t *testing.T) {
+	bl, err := backlog.Open(filepath.Join(t.TempDir(), "BACKLOG.md"))
+	if err != nil {
+		t.Fatalf("backlog.Open: %v", err)
+	}
+	ctx := context.Background()
+	const sha = "0123456789abcdef0123456789abcdef01234567"
+
+	t.Run("second delivery after success is skipped", func(t *testing.T) {
+		disp := &scriptedFixDispatcher{}
+		o := New(disp, bl, slog.New(slog.NewTextHandler(io.Discard, nil)))
+		sig := Signal{Source: SourceCI, Repo: "svc", Kind: KindFail, SHA: sha}
+		o.handle(ctx, sig)
+		o.handle(ctx, sig)
+		if disp.n() != 1 {
+			t.Fatalf("Fix calls = %d, want 1", disp.n())
+		}
+	})
+
+	t.Run("failed Fix can retry the same SHA", func(t *testing.T) {
+		disp := &scriptedFixDispatcher{failUntil: 1}
+		o := New(disp, bl, slog.New(slog.NewTextHandler(io.Discard, nil)))
+		sig := Signal{Source: SourceCI, Repo: "svc", Kind: KindFail, SHA: sha}
+		o.handle(ctx, sig)
+		o.handle(ctx, sig)
+		if disp.n() != 2 {
+			t.Fatalf("Fix calls = %d, want 2 (retry after error)", disp.n())
+		}
+	})
+
+	t.Run("empty SHA is never coalesced", func(t *testing.T) {
+		disp := &scriptedFixDispatcher{}
+		o := New(disp, bl, slog.New(slog.NewTextHandler(io.Discard, nil)))
+		sig := Signal{Source: SourceCI, Repo: "svc", Kind: KindFail}
+		o.handle(ctx, sig)
+		o.handle(ctx, sig)
+		if disp.n() != 2 {
+			t.Fatalf("manual/empty SHA Fix calls = %d, want 2", disp.n())
+		}
+	})
+
+	t.Run("different SHA still Fixes", func(t *testing.T) {
+		disp := &scriptedFixDispatcher{}
+		o := New(disp, bl, slog.New(slog.NewTextHandler(io.Discard, nil)))
+		o.handle(ctx, Signal{Source: SourceCI, Repo: "svc", Kind: KindFail, SHA: sha})
+		o.handle(ctx, Signal{Source: SourceCI, Repo: "svc", Kind: KindFail, SHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+		if disp.n() != 2 {
+			t.Fatalf("Fix calls = %d, want 2", disp.n())
+		}
+	})
 }

--- a/internal/repos/manager.go
+++ b/internal/repos/manager.go
@@ -85,6 +85,13 @@ func NewManager(root string, cfgRepos []config.Repo, tokens ghclient.TokenProvid
 	if tokens == nil {
 		tokens = ghclient.EmptyToken{}
 	}
+	// git worktree add resolves a relative path against the clone, not
+	// the daemon cwd. Default root is "repos", so a relative worktree
+	// path lands inside the clone and the agent chdir misses it
+	// (fork/exec ENOENT). Absolute root keeps worktrees beside clones.
+	if abs, err := filepath.Abs(root); err == nil {
+		root = abs
+	}
 	m := &Manager{
 		root:     root,
 		tokens:   tokens,

--- a/internal/repos/manager.go
+++ b/internal/repos/manager.go
@@ -127,6 +127,9 @@ func (m *Manager) Dir(repo string) string {
 		return filepath.Join(m.root, repo)
 	}
 	if r.Dir != "" {
+		if abs, err := filepath.Abs(r.Dir); err == nil {
+			return abs
+		}
 		return r.Dir
 	}
 	return filepath.Join(m.root, repo)

--- a/internal/repos/worktree.go
+++ b/internal/repos/worktree.go
@@ -90,10 +90,16 @@ func (m *Manager) Worktree(ctx context.Context, repo, id string) (*Worktree, err
 		return nil, fmt.Errorf("repos: unknown repo %q", repo)
 	}
 	base := m.Dir(repo)
+	if abs, err := filepath.Abs(base); err == nil {
+		base = abs
+	}
 	target := m.Branch(repo)
 	dir := m.worktreeDir(repo, id)
 	if abs, err := filepath.Abs(dir); err == nil {
 		dir = abs
+	}
+	if pathInside(base, dir) {
+		return nil, fmt.Errorf("repos: worktree %s would land inside clone %s", dir, base)
 	}
 	branch := worktreeBranchPrefix + safeSegment(id)
 
@@ -124,7 +130,26 @@ func (m *Manager) Worktree(ctx context.Context, repo, id string) (*Worktree, err
 	if err != nil {
 		return nil, fmt.Errorf("repos: worktree add %s: %w", repo, err)
 	}
+	if pathInside(base, dir) {
+		m.markLive(dir, false)
+		_ = m.removeWorktreeAt(ctx, base, dir, branch)
+		return nil, fmt.Errorf("repos: worktree %s resolved inside clone %s", dir, base)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".git")); err != nil {
+		m.markLive(dir, false)
+		_ = m.removeWorktreeAt(ctx, base, dir, branch)
+		return nil, fmt.Errorf("repos: worktree %s has no checkout: %w", dir, err)
+	}
 	return &Worktree{Dir: dir, Branch: branch, Base: base, Target: target, repo: repo}, nil
+}
+
+// pathInside reports whether child is parent or a subdirectory of it.
+func pathInside(parent, child string) bool {
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
 // markLive records (or clears) a worktree as belonging to a running Fix.

--- a/internal/repos/worktree.go
+++ b/internal/repos/worktree.go
@@ -92,6 +92,9 @@ func (m *Manager) Worktree(ctx context.Context, repo, id string) (*Worktree, err
 	base := m.Dir(repo)
 	target := m.Branch(repo)
 	dir := m.worktreeDir(repo, id)
+	if abs, err := filepath.Abs(dir); err == nil {
+		dir = abs
+	}
 	branch := worktreeBranchPrefix + safeSegment(id)
 
 	if err := os.MkdirAll(filepath.Dir(dir), 0o750); err != nil {

--- a/internal/repos/worktree_test.go
+++ b/internal/repos/worktree_test.go
@@ -368,3 +368,21 @@ func TestWorktreeNotNestedWhenRootIsRelative(t *testing.T) {
 		t.Fatalf("agent chdir target missing: %v", err)
 	}
 }
+
+func TestPathInside(t *testing.T) {
+	parent := filepath.Join(string(filepath.Separator), "home", "xdlc", "repos", "svc")
+	cases := []struct {
+		child string
+		want  bool
+	}{
+		{parent, true},
+		{filepath.Join(parent, "repos", ".worktrees", "svc", "run"), true},
+		{filepath.Join(string(filepath.Separator), "home", "xdlc", "repos", ".worktrees", "svc", "run"), false},
+		{filepath.Join(string(filepath.Separator), "tmp", "elsewhere"), false},
+	}
+	for _, c := range cases {
+		if got := pathInside(parent, c.child); got != c.want {
+			t.Errorf("pathInside(%s, %s) = %v, want %v", parent, c.child, got, c.want)
+		}
+	}
+}

--- a/internal/repos/worktree_test.go
+++ b/internal/repos/worktree_test.go
@@ -333,3 +333,38 @@ func TestConcurrentEnsureClonedAndWorktreeAreSerialized(t *testing.T) {
 		}
 	}
 }
+
+// TestWorktreeNotNestedWhenRootIsRelative is the Ubuntu daemon
+// regression: NewManager("repos") plus git -C clone worktree add of a
+// relative path created the checkout inside the clone, then the agent
+// chdir'd to the (empty) path beside it and got fork/exec ENOENT.
+func TestWorktreeNotNestedWhenRootIsRelative(t *testing.T) {
+	_, _, workDir := worktreeFixture(t)
+
+	cwd := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(cwd); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	mgr := NewManager("repos", []config.Repo{
+		{Name: "svc", GitHub: "org/svc", Dir: workDir, Branch: "develop"},
+	}, nil)
+	w, err := mgr.Worktree(context.Background(), "svc", "rel-root")
+	if err != nil {
+		t.Fatalf("Worktree: %v", err)
+	}
+	if !filepath.IsAbs(w.Dir) {
+		t.Fatalf("worktree dir %q is relative; git would nest it in the clone", w.Dir)
+	}
+	if strings.HasPrefix(w.Dir, workDir+string(filepath.Separator)) {
+		t.Fatalf("worktree %s nested inside clone %s", w.Dir, workDir)
+	}
+	if _, err := os.Stat(filepath.Join(w.Dir, "app.txt")); err != nil {
+		t.Fatalf("agent chdir target missing: %v", err)
+	}
+}

--- a/internal/webhook/github.go
+++ b/internal/webhook/github.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -71,7 +72,11 @@ type Server struct {
 	// deliveries are then rejected rather than defaulted — this handler
 	// does not get to guess which branch is a repo's trunk.
 	DefaultBranch string
-	ResolveRepo   func(fullName string) (shortName string, ok bool) // org/repo -> config short name
+	// CIWorkflows is an allowlist of GitHub Actions workflow names or
+	// file basenames. Empty means every completed push workflow_run on
+	// the tracked branch is treated as CI.
+	CIWorkflows []string
+	ResolveRepo func(fullName string) (shortName string, ok bool) // org/repo -> config short name
 	// ResolveArgoApp maps ArgoCD app name -> config short repo name.
 	ResolveArgoApp func(appName string) (shortName string, ok bool)
 	// CheckSmoke runs the repo's real dev-smoke gate — ArgoCD
@@ -125,6 +130,8 @@ type workflowRunEvent struct {
 		// the run tested a commit that is actually on a branch of the
 		// repository — see handleGitHub.
 		Event          string `json:"event"`
+		Name           string `json:"name"`
+		Path           string `json:"path"`
 		Conclusion     string `json:"conclusion"`
 		HeadBranch     string `json:"head_branch"`
 		HeadSHA        string `json:"head_sha"`
@@ -234,6 +241,14 @@ func (s *Server) handleGitHub(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
+	if !matchCIWorkflow(s.CIWorkflows, evt.WorkflowRun.Name, evt.WorkflowRun.Path) {
+		s.Log.Debug("github webhook: ignoring non-CI workflow",
+			"repository", evt.Repository.FullName,
+			"workflow", evt.WorkflowRun.Name,
+			"path", evt.WorkflowRun.Path)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
 
 	kind := orchestrator.KindFail
 	if evt.WorkflowRun.Conclusion == "success" {
@@ -247,15 +262,41 @@ func (s *Server) handleGitHub(w http.ResponseWriter, r *http.Request) {
 		SHA:    evt.WorkflowRun.HeadSHA,
 		At:     time.Now().UTC(),
 		Evidence: map[string]any{
-			"conclusion":  evt.WorkflowRun.Conclusion,
-			"run_url":     evt.WorkflowRun.HTMLURL,
-			"head_sha":    evt.WorkflowRun.HeadSHA,
-			"head_branch": evt.WorkflowRun.HeadBranch,
-			"run_event":   evt.WorkflowRun.Event,
+			"conclusion":    evt.WorkflowRun.Conclusion,
+			"run_url":       evt.WorkflowRun.HTMLURL,
+			"head_sha":      evt.WorkflowRun.HeadSHA,
+			"head_branch":   evt.WorkflowRun.HeadBranch,
+			"run_event":     evt.WorkflowRun.Event,
+			"workflow_name": evt.WorkflowRun.Name,
+			"workflow_path": evt.WorkflowRun.Path,
 		},
 	}
 	s.emit(sig, "github")
 	w.WriteHeader(http.StatusAccepted)
+}
+
+// matchCIWorkflow reports whether a GitHub Actions run is in the CI
+// allowlist. Empty allow means every workflow (back-compat). A list
+// entry matches the workflow name, the path, the basename, or basename
+// without .yml/.yaml (so `ci` matches `.github/workflows/ci.yml`).
+func matchCIWorkflow(allow []string, name, path string) bool {
+	if len(allow) == 0 {
+		return true
+	}
+	base := filepath.Base(path)
+	for _, w := range allow {
+		w = strings.TrimSpace(w)
+		if w == "" {
+			continue
+		}
+		if strings.EqualFold(w, name) || strings.EqualFold(w, path) || strings.EqualFold(w, base) {
+			return true
+		}
+		if strings.EqualFold(w+".yml", base) || strings.EqualFold(w+".yaml", base) {
+			return true
+		}
+	}
+	return false
 }
 
 // argoCDNotification is the payload shape from Argo CD notifications

--- a/internal/webhook/github_test.go
+++ b/internal/webhook/github_test.go
@@ -40,7 +40,7 @@ func resolveTestRepo(name string) (string, bool) {
 // wfRun builds a workflow_run delivery body. Zero fields fall back to a
 // legitimate same-repo push run, so each case only states its deviation.
 type wfRun struct {
-	action, repo, headRepo, event, branch, sha, conclusion string
+	action, repo, headRepo, event, branch, sha, conclusion, name, path string
 }
 
 func (r wfRun) body() []byte {
@@ -50,6 +50,8 @@ func (r wfRun) body() []byte {
 		"repository": {"full_name": %q},
 		"workflow_run": {
 			"event": %q,
+			"name": %q,
+			"path": %q,
 			"conclusion": %q,
 			"head_branch": %q,
 			"head_sha": %q,
@@ -60,6 +62,8 @@ func (r wfRun) body() []byte {
 		or(r.action, "completed"),
 		repo,
 		or(r.event, "push"),
+		or(r.name, "CI"),
+		or(r.path, ".github/workflows/ci.yml"),
 		or(r.conclusion, "failure"),
 		or(r.branch, "develop"),
 		or(r.sha, testSHA),
@@ -291,6 +295,49 @@ func TestHandleGitHubNoBranchConfigured(t *testing.T) {
 	}
 	if len(ch) != 0 {
 		t.Fatal("emitted a signal with no branch configured")
+	}
+}
+
+func TestMatchCIWorkflow(t *testing.T) {
+	cases := []struct {
+		allow      []string
+		name, path string
+		want       bool
+	}{
+		{nil, "Deploy", ".github/workflows/deploy.yml", true},
+		{[]string{}, "Deploy", ".github/workflows/deploy.yml", true},
+		{[]string{"ci"}, "CI", ".github/workflows/ci.yml", true},
+		{[]string{"CI"}, "ci", ".github/workflows/ci.yml", true},
+		{[]string{"ci.yml"}, "CI", ".github/workflows/ci.yml", true},
+		{[]string{".github/workflows/ci.yml"}, "CI", ".github/workflows/ci.yml", true},
+		{[]string{"ci"}, "Deploy", ".github/workflows/deploy.yml", false},
+		{[]string{"ci", "test"}, "Test", ".github/workflows/test.yaml", true},
+	}
+	for _, c := range cases {
+		if got := matchCIWorkflow(c.allow, c.name, c.path); got != c.want {
+			t.Errorf("matchCIWorkflow(%v, %q, %q) = %v, want %v", c.allow, c.name, c.path, got, c.want)
+		}
+	}
+}
+
+func TestHandleGitHubCIWorkflowAllowlist(t *testing.T) {
+	ch := make(chan orchestrator.Signal, 1)
+	srv := githubServer(ch, nil)
+	srv.CIWorkflows = []string{"ci"}
+
+	if got := postGitHub(t, srv, wfRun{name: "CI", path: ".github/workflows/ci.yml"}.body(), "d1"); got != http.StatusAccepted {
+		t.Fatalf("CI workflow: status = %d, want 202", got)
+	}
+	if len(ch) != 1 {
+		t.Fatalf("CI workflow emitted %d signals, want 1", len(ch))
+	}
+	<-ch
+
+	if got := postGitHub(t, srv, wfRun{name: "Deploy", path: ".github/workflows/deploy.yml"}.body(), "d2"); got != http.StatusNoContent {
+		t.Fatalf("Deploy workflow: status = %d, want 204", got)
+	}
+	if len(ch) != 0 {
+		t.Fatalf("Deploy workflow emitted a CI signal: %+v", <-ch)
 	}
 }
 

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -62,7 +62,12 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "trigger": { "type": "string" }
+            "trigger": { "type": "string" },
+            "workflows": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "GitHub Actions workflow names or file basenames that count as CI. Empty = every workflow_run on the branch."
+            }
           }
         },
         "dev-smoke": {


### PR DESCRIPTION
## Summary
- Worktree paths are absolute, and a checkout that would land inside the clone is refused (plus a `.git` check after `worktree add`).
- One successful Fix per repo+SHA this process lifetime, so a flake-ladder `workflow_run` for the same commit does not open a second PR. A failed Fix can still retry. Manual Fix (empty SHA) is unchanged.
- Optional `gates.ci.workflows` allowlist (name, path, or basename such as `ci`). Empty keeps today's behavior: every `workflow_run` on the tracked branch is CI.

Found on Ubuntu dogfood with beta.3 (worktrees on by default, host workaround was `agent.worktree.enabled: false`).

## Test plan
- [x] `go test ./internal/repos ./internal/orchestrator ./internal/webhook ./internal/config`
- [ ] CI on this PR
- [ ] After merge, Ubuntu can turn `agent.worktree.enabled` back on
- [ ] Optional: set `gates.ci.workflows: [ci]` so Deploy does not trigger Fix