### PR TITLE
Release v0.0.1-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.1-beta.5] - 2026-09-08
+
 ### Fixed
 
 - **A Fix that delivered nothing permanently marked the commit as fixed** (#34). A no-commit run returned no error, so the SHA was latched as fixed and every later delivery for it short-circuited to `already_fixed`, with no eviction. One agent timeout, OOM or bad prompt left that commit unfixable until the daemon restarted. `Dispatcher.Fix` now reports whether a fix was actually delivered, and only a delivered Fix latches the SHA. A genuinely successful Fix still suppresses a second Fix for the same commit, which is the guarantee added in d75b2c2. Runs that delivered nothing show `fix_delivered=false` in the audit row

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ export PATH="$HOME/.local/bin:$PATH"   # if needed
 xdlc demo --provider fake
 ```
 
-Pin a release: `XDLC_VERSION=v0.0.1-beta.4`. More options: **[Install](https://xdlc.dev/agent/docs)**.
+Pin a release: `XDLC_VERSION=v0.0.1-beta.5`. More options: **[Install](https://xdlc.dev/agent/docs)**.
 
 Then a real daemon:
 
@@ -70,7 +70,7 @@ docker run --rm -p 8080:8080 \
   -v "$PWD/config.yaml:/etc/xdlc-agent/config.yaml:ro" \
   -e XDLC_API_TOKEN -e GITHUB_TOKEN -e GITHUB_WEBHOOK_SECRET \
   -e ANTHROPIC_API_KEY -e OPENAI_API_KEY -e CURSOR_API_KEY \
-  ghcr.io/xdlc-labs/xdlc-agent:0.0.1-beta.4 \
+  ghcr.io/xdlc-labs/xdlc-agent:0.0.1-beta.5 \
   daemon --config /etc/xdlc-agent/config.yaml
 ```
 
@@ -78,7 +78,7 @@ docker run --rm -p 8080:8080 \
 
 ```sh
 helm install xdlc-agent deploy/helm/xdlc-agent \
-  --set image.tag=0.0.1-beta.4 \
+  --set image.tag=0.0.1-beta.5 \
   --set existingSecret=xdlc-agent-secrets \
   --set-file config=config.yaml
 ```

--- a/deploy/helm/xdlc-agent/Chart.yaml
+++ b/deploy/helm/xdlc-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: xdlc-agent
 description: xdlc orchestrator — CI Fix daemon; GitOps / prod gates optional
 type: application
-version: 0.0.1-beta.4
-appVersion: "0.0.1-beta.4"
+version: 0.0.1-beta.5
+appVersion: "0.0.1-beta.5"
 home: https://github.com/xdlc-labs/xdlc-agent
 sources:
   - https://github.com/xdlc-labs/xdlc-agent


### PR DESCRIPTION
**What this changes**

Version bump only, no behaviour change. Chart `version`/`appVersion` to `0.0.1-beta.5`, the README's three release references, and the changelog's `Unreleased` section closed under `[0.0.1-beta.5] - 2026-09-08`.

**Why beta.5 and not 0.1.0.** The changelog already carries `[0.1.0]`, `[1.0.0]` and `[2.0.0]` headings dated 2026-09-04, from before the project reset to `0.0.1-beta`. None of those were ever tagged; the only tags are `v0.0.1-beta.1` through `.4`. Opening `0.1.0` or `0.1.0-beta.1` now would collide with an existing heading and sort below it, so this continues the series that actually shipped. Reconciling those old headings is worth doing before any real `0.1.0`, but it is a separate decision from shipping these fixes.

**What the release delivers**, from #33 and #38:

- The coding agent can commit in the published container, so a containerized Fix actually delivers instead of silently producing nothing.
- The documented first run starts. `xdlc init`, then `doctor`, then `daemon` no longer dead-ends.
- A webhook branch mismatch is logged instead of dropping every delivery silently.
- A Fix that delivered nothing no longer marks the commit as fixed forever.
- The PR work queue can see GitHub Actions check runs.
- The curl install works on Debian and Ubuntu.

**Still blocked after this merges.** The GHCR package is private while the repo is public, so the container instructions in this release stay unusable from outside the org until its visibility changes. There is no REST endpoint for it; `RELEASING.md` carries the step and a one-line unauthenticated curl to confirm it. The binary install path via `scripts/install.sh` and GitHub Releases is unaffected and was verified working end to end.

**Note on the hosted guides.** `ui/content/docs/` is gitignored in this repo, so the four install, deployment and getting-started version references I bumped locally are not in this diff. They live in the documentation repository and need the same bump there, or the next sync restores the old tag. `scripts/check-version-refs.sh` skips untracked files in CI for exactly this reason and says so, which means CI only proves `README.md` and the chart.

**Checklist**
- [x] `make build && make test && make lint` clean
- [x] `test -z "$(gofmt -l cmd internal services)"`
- [x] `./scripts/check-version-refs.sh` passes at the new version; `helm lint` clean and `helm template` resolves the image to `0.0.1-beta.5`
- [x] UI not touched
- [x] No vendor-specific logic changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
