### PR TITLE
Make a gate that cannot run as visible as one that failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,31 +6,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-Verifying the two opt-in legs (#25, #26) end to end turned up six confirmed bugs, four of
-which damaged production silently. All six are fixed here.
-
-### Fixed
-
-- **A promote rewrote every `tag:` line in the prod values file** (#43). The regexp matched any `^\s*tag:`, so an unrelated `sidecar.image.tag` was rewritten to the promoted service's image SHA. Any values file with a sidecar, init container or sub-chart sent those containers into `ImagePullBackOff` in production, from a promote whose audit row said `ok=true`. The tag is now located structurally, by addressing `image.tag` through the YAML node tree, and written by splicing just that scalar's bytes, so every other byte of the file survives. The result is re-parsed and re-checked before it is committed, and a tag that is not a plain image tag is refused rather than written. Reads use the same locator, so `promote_requires` pins no longer see the first `tag:` in the file
-- **A promote deleted a blank line and stripped the file's trailing newline** (#43), every time, because the regexp's trailing `\s*$` consumed the following newline. That fought any YAML formatter or `end-of-file-fixer` hook in the GitOps repo. Whitespace is now preserved byte-for-byte
-- **A missing values file made the image carry a silent no-op that still reported success** (#44). The prod branch was fast-forwarded while prod kept its old image, with no warn, no evidence field and nothing in the audit row to distinguish it from a real carry. The outcome is now recorded as `tag_carry` in the audit evidence and on the `promoted` log line, a missing file warns and lists what the values directory actually contains (which names a misnamed file directly), and a half-configured repo, where exactly one of the dev and prod values files exists, is now an error rather than a shrug. A repo with neither file is still fine, since fast-forward-only is a real topology
-- **Repeated firing alerts reverted the revert, putting the bad commit back in production** (#40). Alertmanager re-sends a firing notification every `repeat_interval` for as long as the alert fires, and the webhook treated each delivery as a fresh breach, so an even number of notifications left prod on the bad commit behind a row of `Revert / ok=true` audit entries. The pushed path is now edge-triggered per repo, like the poller: a breach emits once, a resolve re-arms it, and a genuine new breach still reverts. It deliberately keeps its own state rather than reading the orchestrator's, which is only updated once a signal is handled and so races two fast notifications
-- **`repos[].gates` was ignored on the Alertmanager path** (#41), so every repo in `config.yaml` was revertable by anything holding the shared webhook secret, including repos whose operator never enabled prod-health. Reproduced against a repo configured `gates: [ci]`. The pushed path now applies the same gate filter the polled path does and declines the alert out loud. An unwired filter declines everything rather than allowing everything
-- **A hung Prometheus silently and permanently disabled the prod-health gate** (#42). With no client timeout, no per-tick deadline and a synchronous tick, one unanswered query parked the ticker loop for the life of the process: a stub that accepted connections and never answered produced exactly one query in 30 seconds and not one line of log. Each tick now gets a deadline, and an overrun is logged as an error instead of being absorbed. Measured on the same stub: one silent query in 30 seconds became nine queries and eighteen operator-visible lines
-- `validate` no longer demands `metrics_url`, `p95_query` and `error_rate_query` for a webhook-only prod-health deployment, which previously could not be configured without pointing at a metrics endpoint it never intended to poll. Queries configured without a `metrics_url` are now flagged specifically
-
-### Added
-
-- `gates.prod-health.timeout` — the per-tick deadline for the PromQL queries. Unset means 80% of `interval`, deliberately the same fraction at which a tick already warned that it was slow, so the point a tick was considered unhealthy is now also the point it is abandoned and logged. Keeping it under one interval means ticks cannot stack
-- Test coverage for the Alertmanager **accept** path, which had none: the secret appeared in no test file, and both existing handler tests left it empty, so "a correctly credentialed alert is accepted" was unproven at every level
-
-### Changed
-
-- The per-tick deadline applies to the dev-smoke and external-gate pollers too, bounding them at 80% of their interval. That is the threshold at which they already warned, so nothing previously considered healthy is now cancelled, but a probe that legitimately runs past 80% of its interval now needs a larger `interval`
-- `xdlc init --profile gitops` and `--profile full` set `prod_branch` explicitly and say which GitOps values files the operator still has to create. They scaffolded neither before, which landed opt-in users straight in the silent no-op above
-- `promote.CarryProdTag` now returns a `promote.Carry` describing what happened, rather than a bare bool
-
 ## [0.0.1-beta.5] - 2026-09-08
+
+This release exists because verifying the open adoption issues turned the daemon's own
+documented paths into a list of things that did not work. The container could not commit,
+the documented first run would not start, a webhook branch mismatch was silent, and both
+opt-in legs could damage production while reporting success.
 
 ### Fixed
 
@@ -46,6 +27,16 @@ which damaged production silently. All six are fixed here.
 - A flaky `internal/session` test. `Start` fires a rate-limited background prune that is ungated on a fresh store, so it raced `TestPruneDropsOldSessions` for the stale directory and the explicit `Prune()` then had nothing to remove (`want 1 pruned, got 0`, roughly once per 30 package runs). Test-only: the daemon tolerates a concurrent prune. The test now claims the rate limit so it owns the only prune
 - The documented curl install is piped into **bash**, not `sh`. `scripts/install.sh` uses `set -o pipefail`, which dash rejects outright, so `curl … | sh` died with `set: Illegal option -o pipefail` before doing anything on Debian and Ubuntu, where `/bin/sh` is dash. The script itself was fine; only the documented invocation was wrong
 - Console **Settings** no longer reads as one coding-agent control and a broken echo of it. The browser-local Manual Fix override and the daemon's `agent.provider` default are now two labelled, visually distinct cards, the daemon one explicitly read-only with the "edit config.yaml and restart" instruction. When the two differ, a calm note says which one wins for a Manual Fix from this browser instead of leaving what looked like a failed save (#29)
+- **A typo'd `argocd_app` made the promote gate die in total silence** (#45). The ArgoCD CLI's stderr was discarded, so every cause — a wrong app name, an expired session, a missing kubeconfig, an RBAC denial — read as `exit status 20`; and because the smoke gate returned an error rather than a verdict, the webhook answered 204 and the poller only logged, leaving no signal, no audit row and no `BACKLOG.md` line. Promote then simply never fired again. Stderr is now carried into the error, and a gate that could not run emits a distinct `blocked` signal recorded with `escalate=gate_unavailable` and the underlying reason. It is deliberately **not** a fail: `Decide` maps `blocked` to a noop before the source switch, so an unreachable ArgoCD can never route to a Fix and spend a coding-agent run on a repo that is not broken. Measured against a stub `argocd`: what was one log line with no diagnostic and zero recorded rows is now an error naming the real cause, plus a `BACKLOG.md` line and an audit row
+- `xdlc doctor` no longer green-lights a config whose dev-smoke gate cannot run. It checked only `repos[].argocd_app`, ignoring the `gates.dev-smoke.argocd_app` fallback that `gatebuild` and `validate` both honour, so two semantically identical configs got opposite verdicts. All three now share one resolver
+- `xdlc validate --gitops-dir` reports an issue instead of aborting with a usage dump when the tree has no `apps/dev` directory, matching how the role-namespace check already behaved
+- **A promote rewrote every `tag:` line in the prod values file** (#43). The regexp matched any `^\s*tag:`, so an unrelated `sidecar.image.tag` was rewritten to the promoted service's image SHA. Any values file with a sidecar, init container or sub-chart sent those containers into `ImagePullBackOff` in production, from a promote whose audit row said `ok=true`. The tag is now located structurally, by addressing `image.tag` through the YAML node tree, and written by splicing just that scalar's bytes, so every other byte of the file survives. The result is re-parsed and re-checked before it is committed, and a tag that is not a plain image tag is refused rather than written. Reads use the same locator, so `promote_requires` pins no longer see the first `tag:` in the file
+- **A promote deleted a blank line and stripped the file's trailing newline** (#43), every time, because the regexp's trailing `\s*$` consumed the following newline. That fought any YAML formatter or `end-of-file-fixer` hook in the GitOps repo. Whitespace is now preserved byte-for-byte
+- **A missing values file made the image carry a silent no-op that still reported success** (#44). The prod branch was fast-forwarded while prod kept its old image, with no warn, no evidence field and nothing in the audit row to distinguish it from a real carry. The outcome is now recorded as `tag_carry` in the audit evidence and on the `promoted` log line, a missing file warns and lists what the values directory actually contains (which names a misnamed file directly), and a half-configured repo, where exactly one of the dev and prod values files exists, is now an error rather than a shrug. A repo with neither file is still fine, since fast-forward-only is a real topology
+- **Repeated firing alerts reverted the revert, putting the bad commit back in production** (#40). Alertmanager re-sends a firing notification every `repeat_interval` for as long as the alert fires, and the webhook treated each delivery as a fresh breach, so an even number of notifications left prod on the bad commit behind a row of `Revert / ok=true` audit entries. The pushed path is now edge-triggered per repo, like the poller: a breach emits once, a resolve re-arms it, and a genuine new breach still reverts. It deliberately keeps its own state rather than reading the orchestrator's, which is only updated once a signal is handled and so races two fast notifications
+- **`repos[].gates` was ignored on the Alertmanager path** (#41), so every repo in `config.yaml` was revertable by anything holding the shared webhook secret, including repos whose operator never enabled prod-health. Reproduced against a repo configured `gates: [ci]`. The pushed path now applies the same gate filter the polled path does and declines the alert out loud. An unwired filter declines everything rather than allowing everything
+- **A hung Prometheus silently and permanently disabled the prod-health gate** (#42). With no client timeout, no per-tick deadline and a synchronous tick, one unanswered query parked the ticker loop for the life of the process: a stub that accepted connections and never answered produced exactly one query in 30 seconds and not one line of log. Each tick now gets a deadline, and an overrun is logged as an error instead of being absorbed. Measured on the same stub: one silent query in 30 seconds became nine queries and eighteen operator-visible lines
+- `validate` no longer demands `metrics_url`, `p95_query` and `error_rate_query` for a webhook-only prod-health deployment, which previously could not be configured without pointing at a metrics endpoint it never intended to poll. Queries configured without a `metrics_url` are now flagged specifically
 
 ### Added
 
@@ -55,13 +46,18 @@ which damaged production silently. All six are fixed here.
 - Airlock runs on pull requests (`.github/workflows/airlock.yml`)
 - [ROADMAP.md](ROADMAP.md) — what is planned next, and what is deliberately out of scope; linked from the README
 - [RELEASING.md](RELEASING.md) — the release checklist, including the manual GHCR package-visibility step that CI cannot do and the from-source image build's disk and podman requirements
+- `gates.prod-health.timeout` — the per-tick deadline for the PromQL queries. Unset means 80% of `interval`, deliberately the same fraction at which a tick already warned that it was slow, so the point a tick was considered unhealthy is now also the point it is abandoned and logged. Keeping it under one interval means ticks cannot stack
+- Test coverage for the Alertmanager **accept** path, which had none: the secret appeared in no test file, and both existing handler tests left it empty, so "a correctly credentialed alert is accepted" was unproven at every level
 
 ### Changed
 
-- Install and deployment guides pin the current release (`0.0.1-beta.4`) consistently
+- Install and deployment guides pin the current release consistently, and CI now enforces it. They had drifted to `0.0.1-beta.1` and `0.0.1-beta.2` while the README was on `0.0.1-beta.4`, so a new user's first `docker run` pulled a stale image
 - The container and Kubernetes paths document that they need `server.require_webhook_secret: true` plus a `GITHUB_WEBHOOK_SECRET`, since a container never binds loopback. The Helm chart already set it
 - The README no longer explains a GHCR `unauthorized` as a missing tag; the tags exist, the package is not public
 - `deploy/Dockerfile.release` no longer points at `scripts/bootstrap-local.sh`, which does not exist
+- The per-tick deadline applies to the dev-smoke and external-gate pollers too, bounding them at 80% of their interval. That is the threshold at which they already warned, so nothing previously considered healthy is now cancelled, but a probe that legitimately runs past 80% of its interval now needs a larger `interval`
+- `xdlc init --profile gitops` and `--profile full` set `prod_branch` explicitly and say which GitOps values files the operator still has to create. They scaffolded neither before, which landed opt-in users straight in the silent no-op above
+- `promote.CarryProdTag` now returns a `promote.Carry` describing what happened, rather than a bare bool
 
 ## [0.0.1-beta.4] - 2026-09-07
 

--- a/cmd/xdlc-agent/audit_status_test.go
+++ b/cmd/xdlc-agent/audit_status_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/xdlc-labs/xdlc-agent/internal/orchestrator"
+	"github.com/xdlc-labs/xdlc-agent/internal/store"
+)
+
+// TestAuditStatusMarksAnUnrunnableGate: the audit row is the record an
+// operator reads in `xdlc history` and the console Activity feed. A gate
+// that could not run dispatches nothing, so it used to be indistinguishable
+// from a clean noop there (issue #45).
+func TestAuditStatusMarksAnUnrunnableGate(t *testing.T) {
+	blocked := orchestrator.Blocked(orchestrator.SourceDevGate, "svc", "dev-smoke", "abc1234",
+		errors.New(`gitops: argocd app get dev-typo: exit status 20: applications.argoproj.io "dev-typo" not found`))
+
+	status, errMsg := auditStatus(blocked, nil)
+	if status != store.StatusError {
+		t.Fatalf("status = %q, want %q — a dead gate must not read ok", status, store.StatusError)
+	}
+	if errMsg == "" {
+		t.Fatal("no reason recorded on the audit row")
+	}
+	// The row must read ok=false in `xdlc history` and the console.
+	if (store.Record{Status: status}).Succeeded() {
+		t.Fatal("blocked row counts as a successful dispatch")
+	}
+
+	// A real gate fail is a *successful* dispatch of a Fix, so it stays
+	// ok=true — that is what keeps the two distinguishable.
+	failed := orchestrator.Signal{Source: orchestrator.SourceDevGate, Repo: "svc", Kind: orchestrator.KindFail}
+	if status, errMsg := auditStatus(failed, nil); status != store.StatusOK || errMsg != "" {
+		t.Fatalf("gate fail = (%q, %q), want (%q, \"\")", status, errMsg, store.StatusOK)
+	}
+
+	// A dispatch error still wins, and reports its own message.
+	if status, errMsg := auditStatus(failed, errors.New("git push rejected")); status != store.StatusError || errMsg != "git push rejected" {
+		t.Fatalf("dispatch error = (%q, %q)", status, errMsg)
+	}
+	// Even on a blocked signal: the dispatch error is the more specific fact.
+	if _, errMsg := auditStatus(blocked, errors.New("boom")); errMsg != "boom" {
+		t.Fatalf("dispatch error lost on a blocked signal: %q", errMsg)
+	}
+}

--- a/cmd/xdlc-agent/doctor.go
+++ b/cmd/xdlc-agent/doctor.go
@@ -96,7 +96,13 @@ Exit 1 when any required check fails.`,
 						needKubectl = true
 					}
 				}
-				if r.ArgoCDApp != "" {
+				// The same resolver gatebuild.DevSmoke builds the gate
+				// with, so the shared gates.dev-smoke.argocd_app
+				// fallback counts here too. Reading r.ArgoCDApp alone
+				// gave two semantically identical configs opposite
+				// verdicts and green-lit one whose dev-smoke gate could
+				// not run (issue #45).
+				if validate.ResolveArgoCDApp(cfg, r) != "" {
 					needArgo = true
 				}
 			}

--- a/cmd/xdlc-agent/doctor_test.go
+++ b/cmd/xdlc-agent/doctor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -224,5 +225,139 @@ agent:
 				t.Fatalf("expected ok webhook secret for listen addr:\n%s", buf.String())
 			}
 		})
+	}
+}
+
+// runDoctor executes `doctor --skip-network` against body and returns
+// its output plus whether it failed.
+func runDoctor(t *testing.T, body string) (string, bool) {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfg, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// A PATH we control, so the verdict does not depend on whether the
+	// machine running the test happens to have `argocd` installed.
+	// doctor only LookPath's these, so a stub is enough; `git` doubles
+	// as the agent CLI, as the other doctor tests do.
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "git"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+	t.Setenv("XDLC_API_TOKEN", "dev-token")
+	t.Setenv("GITHUB_TOKEN", "ghp_test")
+
+	cfgPath = cfg
+	cmd := doctorCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--skip-network"})
+	err := cmd.Execute()
+	return buf.String(), err != nil
+}
+
+// argocdLine extracts the "argocd on PATH" verdict line.
+func argocdLine(t *testing.T, out string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "argocd on PATH") {
+			return line
+		}
+	}
+	t.Fatalf("no argocd check in doctor output:\n%s", out)
+	return ""
+}
+
+// TestDoctorTreatsSharedAndPerRepoArgoCDAppIdentically is issue #45's
+// third part. doctor read repos[].argocd_app only, while gatebuild and
+// validate both fall back to gates.dev-smoke.argocd_app — so with
+// `argocd` off PATH two semantically identical configs got opposite
+// verdicts and doctor green-lit one whose dev-smoke gate cannot run.
+func TestDoctorTreatsSharedAndPerRepoArgoCDAppIdentically(t *testing.T) {
+	const perRepo = `
+repos:
+  - name: svc
+    github: org/svc
+    branch: develop
+    gates: [dev-smoke]
+    argocd_app: dev-svc
+    probe_job: smoke-e2e
+server:
+  addr: "127.0.0.1:8080"
+  require_webhook_secret: false
+gates:
+  dev-smoke:
+    trigger: on_sync
+agent:
+  provider: claude
+  binary: git
+`
+	const sharedDefault = `
+repos:
+  - name: svc
+    github: org/svc
+    branch: develop
+    gates: [dev-smoke]
+server:
+  addr: "127.0.0.1:8080"
+  require_webhook_secret: false
+gates:
+  dev-smoke:
+    trigger: on_sync
+    argocd_app: dev-svc
+    probe_job: smoke-e2e
+agent:
+  provider: claude
+  binary: git
+`
+	perRepoOut, perRepoFailed := runDoctor(t, perRepo)
+	sharedOut, sharedFailed := runDoctor(t, sharedDefault)
+
+	perRepoArgo := argocdLine(t, perRepoOut)
+	sharedArgo := argocdLine(t, sharedOut)
+	if perRepoArgo != sharedArgo {
+		t.Fatalf("two semantically identical configs got different argocd verdicts:\n"+
+			"per-repo:  %s\nshared:    %s", perRepoArgo, sharedArgo)
+	}
+	// Both must be a FAIL: argocd is not on the PATH the test built, and
+	// the dev-smoke gate cannot run without it.
+	if !strings.Contains(perRepoArgo, "FAIL") {
+		t.Fatalf("argocd is off PATH but the check passed:\n%s", perRepoArgo)
+	}
+	if !perRepoFailed || !sharedFailed {
+		t.Fatalf("doctor green-lit a config whose dev-smoke gate cannot run "+
+			"(per-repo failed=%v, shared failed=%v)\n--- per-repo ---\n%s\n--- shared ---\n%s",
+			perRepoFailed, sharedFailed, perRepoOut, sharedOut)
+	}
+}
+
+// TestDoctorArgoCDNotRequiredWithoutAnApp: the check stays warn-style —
+// a config with no resolved argocd_app at all must not demand the binary.
+func TestDoctorArgoCDNotRequiredWithoutAnApp(t *testing.T) {
+	const ciOnly = `
+repos:
+  - name: svc
+    github: org/svc
+    branch: develop
+    gates: [ci]
+server:
+  addr: "127.0.0.1:8080"
+  require_webhook_secret: false
+gates:
+  ci:
+    trigger: on_push
+agent:
+  provider: claude
+  binary: git
+`
+	out, failed := runDoctor(t, ciOnly)
+	if line := argocdLine(t, out); strings.Contains(line, "FAIL") {
+		t.Fatalf("argocd required by a ci-only config:\n%s", line)
+	}
+	if failed {
+		t.Fatalf("ci-only config failed doctor:\n%s", out)
 	}
 }

--- a/cmd/xdlc-agent/main.go
+++ b/cmd/xdlc-agent/main.go
@@ -279,12 +279,7 @@ func daemonCmd() *cobra.Command {
 			}
 			o.Suppressions = metrics.FleetSuppressions
 			o.Audit = func(s orchestrator.Signal, action orchestrator.Action, dispatchErr error, started time.Time) error {
-				status := store.StatusOK
-				errMsg := ""
-				if dispatchErr != nil {
-					status = store.StatusError
-					errMsg = dispatchErr.Error()
-				}
+				status, errMsg := auditStatus(s, dispatchErr)
 				provider := ""
 				if s.Evidence != nil {
 					if v, ok := s.Evidence["agent_provider"].(string); ok {
@@ -1050,4 +1045,25 @@ func parseGitHubRemote(remote string) string {
 		return ""
 	}
 	return parts[0] + "/" + parts[1]
+}
+
+// auditStatus classifies one signal+dispatch outcome for the audit
+// store: the Status and Error an `xdlc history` row (and the console
+// Activity feed, which shows the same record) will carry.
+//
+// A KindBlocked signal dispatched nothing, so there is no dispatchErr —
+// but recording it as ok would make "ArgoCD is unreachable" or a typo'd
+// argocd_app look like a clean noop, which is the invisibility issue #45
+// is about. It is the daemon failing to do its job, so the row reads
+// ok=false and carries the reason the gate could not run. That is still
+// distinguishable from a gate *fail*, which arrives as Kind "fail" with
+// action fix/revert.
+func auditStatus(s orchestrator.Signal, dispatchErr error) (status, errMsg string) {
+	if dispatchErr != nil {
+		return store.StatusError, dispatchErr.Error()
+	}
+	if reason, blocked := orchestrator.BlockedReason(s); blocked {
+		return store.StatusError, reason
+	}
+	return store.StatusOK, ""
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -910,6 +910,13 @@ func mapKindStatus(kind string) string {
 		return "pass"
 	case "fail", "breach":
 		return "fail"
+	case string(orchestrator.KindBlocked):
+		// The gate could not run, so it has no verdict — "waiting" is
+		// the console vocabulary for that. Not "idle", which means
+		// "nothing has happened yet" and would show a dead gate as a
+		// quiet one (issue #45); not "fail", which is a verdict about
+		// the software.
+		return "waiting"
 	default:
 		return "idle"
 	}
@@ -920,6 +927,11 @@ func mapHealth(r store.Record) string {
 		return "breach"
 	}
 	if r.Kind == "fail" {
+		return "degraded"
+	}
+	if r.Kind == string(orchestrator.KindBlocked) {
+		// Unknown, not well: the last thing this repo's gate did was
+		// fail to run, so the row must not read "healthy".
 		return "degraded"
 	}
 	return "healthy"

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -696,3 +696,44 @@ func TestHistoryManualSourceIsDaemon(t *testing.T) {
 		t.Fatalf("gate=%v, want CI for a manual Fix", m["gate"])
 	}
 }
+
+// TestBlockedRecordIsNotShownAsHealthyOrIdle: the console reads the same
+// audit rows as `xdlc history`. A gate that could not run has no
+// verdict, so it must not render as a quiet ("idle") gate on a
+// ("healthy") repo — that is the invisibility of issue #45 reappearing
+// in the browser.
+func TestBlockedRecordIsNotShownAsHealthyOrIdle(t *testing.T) {
+	blocked := string(orchestrator.KindBlocked)
+
+	if got := mapKindStatus(blocked); got == "idle" {
+		t.Error("a gate that could not run renders as idle")
+	}
+	if got := mapKindStatus(blocked); got == "pass" || got == "fail" {
+		t.Errorf("blocked renders as %q — indistinguishable from a verdict", got)
+	}
+	if got := mapKindStatus(blocked); got != "waiting" {
+		t.Errorf("mapKindStatus(blocked) = %q, want waiting", got)
+	}
+
+	rec := store.Record{Repo: "svc", Source: "dev-gate", Kind: blocked, Action: "noop"}
+	if got := mapHealth(rec); got == "healthy" {
+		t.Error("a repo whose gate could not run reports healthy")
+	}
+	if got := mapHealth(rec); got != "degraded" {
+		t.Errorf("mapHealth(blocked) = %q, want degraded", got)
+	}
+
+	// Unchanged for the verdicts.
+	if got := mapKindStatus("pass"); got != "pass" {
+		t.Errorf("pass = %q", got)
+	}
+	if got := mapKindStatus("fail"); got != "fail" {
+		t.Errorf("fail = %q", got)
+	}
+	if got := mapHealth(store.Record{Source: "prod-health", Kind: "breach"}); got != "breach" {
+		t.Errorf("breach = %q", got)
+	}
+	if got := mapHealth(store.Record{Source: "ci", Kind: "pass"}); got != "healthy" {
+		t.Errorf("pass = %q", got)
+	}
+}

--- a/internal/gatebuild/build.go
+++ b/internal/gatebuild/build.go
@@ -13,6 +13,7 @@ import (
 	"github.com/xdlc-labs/xdlc-agent/internal/gitops"
 	"github.com/xdlc-labs/xdlc-agent/internal/k8sprobe"
 	"github.com/xdlc-labs/xdlc-agent/internal/promclient"
+	"github.com/xdlc-labs/xdlc-agent/internal/validate"
 )
 
 // CI builds the one CIGate instance shared across all repos —
@@ -62,14 +63,11 @@ func DevSmoke(cfg *config.Config) map[string]*gate.SmokeGate {
 
 	gates := make(map[string]*gate.SmokeGate, len(cfg.Repos))
 	for _, r := range cfg.Repos {
-		app := r.ArgoCDApp
-		if app == "" {
-			app = cfg.Gates.DevSmoke.ArgoCDApp
-		}
-		job := r.ProbeJob
-		if job == "" {
-			job = cfg.Gates.DevSmoke.ProbeJob
-		}
+		// One resolver, shared with validate and `xdlc doctor`, so
+		// what doctor says the gate needs is what the gate is actually
+		// built with (issue #45).
+		app := validate.ResolveArgoCDApp(cfg, r)
+		job := validate.ResolveProbeJob(cfg, r)
 		if app == "" || job == "" {
 			continue // repo has no dev-smoke config, skip
 		}

--- a/internal/gitops/argocd.go
+++ b/internal/gitops/argocd.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"strings"
 )
 
 // ArgoCDClient shells out to the `argocd` CLI (assumes an authenticated
@@ -30,7 +31,21 @@ type appStatus struct {
 	} `json:"status"`
 }
 
+// maxStderrBytes caps how much of the CLI's stderr is carried into an
+// error. The message ends up in gate evidence, a BACKLOG.md line and an
+// audit row, so it has to stay one readable line rather than however
+// many kilobytes a failing CLI decides to print.
+const maxStderrBytes = 512
+
 // AppHealthy reports true if app is both Synced and Healthy.
+//
+// A failing `argocd` is the single most common way this gate stops
+// working, and every distinct cause — a typo'd app name, an expired
+// session, a missing kubeconfig, an RBAC denial — exits non-zero. The
+// CLI says which one it was on *stderr*, so stderr is captured and
+// carried into the error: without it every failure reads as
+// "exit status 20" and an operator cannot tell a config typo from a
+// dead cluster (issue #45).
 func (c *ArgoCDClient) AppHealthy(ctx context.Context, app string) (bool, error) {
 	bin := c.Binary
 	if bin == "" {
@@ -40,15 +55,30 @@ func (c *ArgoCDClient) AppHealthy(ctx context.Context, app string) (bool, error)
 	// this daemon's own gates.dev-smoke.argocd_app config value — not
 	// external input.
 	cmd := exec.CommandContext(ctx, bin, "app", "get", app, "-o", "json") //nolint:gosec
-	var out bytes.Buffer
+	var out, errOut bytes.Buffer
 	cmd.Stdout = &out
+	cmd.Stderr = &errOut
 	if err := cmd.Run(); err != nil {
-		return false, fmt.Errorf("gitops: argocd app get %s: %w", app, err)
+		return false, fmt.Errorf("gitops: argocd app get %s: %w%s", app, err, stderrDetail(errOut.Bytes()))
 	}
 
 	var s appStatus
 	if err := json.Unmarshal(out.Bytes(), &s); err != nil {
-		return false, fmt.Errorf("gitops: parse argocd status: %w", err)
+		return false, fmt.Errorf("gitops: parse argocd status: %w%s", err, stderrDetail(errOut.Bytes()))
 	}
 	return s.Status.Sync.Status == "Synced" && s.Status.Health.Status == "Healthy", nil
+}
+
+// stderrDetail renders captured stderr as a ": ..." suffix for an error
+// message — collapsed to one line and truncated — or "" when the command
+// printed nothing.
+func stderrDetail(b []byte) string {
+	text := strings.Join(strings.Fields(string(b)), " ")
+	if text == "" {
+		return ""
+	}
+	if len(text) > maxStderrBytes {
+		text = text[:maxStderrBytes] + "…"
+	}
+	return ": " + text
 }

--- a/internal/gitops/argocd_test.go
+++ b/internal/gitops/argocd_test.go
@@ -60,3 +60,81 @@ func TestNewArgoCDClient(t *testing.T) {
 		t.Fatal(NewArgoCDClient().Binary)
 	}
 }
+
+// TestAppHealthyExecErrorCarriesStderr is issue #45's first half. The
+// CLI's stderr used to be discarded, so a typo'd argocd_app, an expired
+// session, a missing kubeconfig and an RBAC denial were all
+// indistinguishable "exit status 20".
+func TestAppHealthyExecErrorCarriesStderr(t *testing.T) {
+	cases := []struct {
+		name   string
+		script string
+		want   string
+	}{
+		{
+			"unknown app",
+			`echo 'rpc error: code = NotFound desc = applications.argoproj.io "dev-typo" not found' >&2; exit 20`,
+			`"dev-typo" not found`,
+		},
+		{
+			"expired session",
+			`echo 'rpc error: code = Unauthenticated desc = token has expired' >&2; exit 20`,
+			"token has expired",
+		},
+		{
+			"no kubeconfig",
+			`echo 'error: could not read kubeconfig: no such file or directory' >&2; exit 1`,
+			"could not read kubeconfig",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			bin := writeFake(t, c.script)
+			_, err := (&ArgoCDClient{Binary: bin}).AppHealthy(context.Background(), "dev-typo")
+			if err == nil {
+				t.Fatal("want an error")
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Fatalf("error does not say why the CLI failed:\n%s", err)
+			}
+			// The old message, still there so the failing command is named.
+			if !strings.Contains(err.Error(), "argocd app get dev-typo") {
+				t.Fatalf("error no longer names the command:\n%s", err)
+			}
+		})
+	}
+}
+
+// TestAppHealthyStderrIsOneBoundedLine: the message lands in gate
+// evidence, a BACKLOG.md line and an audit row, all of which are one
+// line per record.
+func TestAppHealthyStderrIsOneBoundedLine(t *testing.T) {
+	bin := writeFake(t, `awk 'BEGIN{for(i=0;i<400;i++) print "noise line", i}' >&2; exit 20`)
+	_, err := (&ArgoCDClient{Binary: bin}).AppHealthy(context.Background(), "myapp")
+	if err == nil {
+		t.Fatal("want an error")
+	}
+	msg := err.Error()
+	if strings.ContainsAny(msg, "\n\r\t") {
+		t.Fatalf("error spans multiple lines:\n%q", msg)
+	}
+	if len(msg) > maxStderrBytes+200 {
+		t.Fatalf("error is %d bytes, want it truncated near %d", len(msg), maxStderrBytes)
+	}
+	if !strings.HasSuffix(msg, "…") {
+		t.Fatalf("truncation not marked:\n%s", msg)
+	}
+}
+
+// TestAppHealthySilentFailureStillReadable: a CLI that prints nothing on
+// stderr must not leave a dangling ": ".
+func TestAppHealthySilentFailureStillReadable(t *testing.T) {
+	bin := writeFake(t, `exit 20`)
+	_, err := (&ArgoCDClient{Binary: bin}).AppHealthy(context.Background(), "myapp")
+	if err == nil {
+		t.Fatal("want an error")
+	}
+	if strings.HasSuffix(err.Error(), ": ") || strings.HasSuffix(err.Error(), ":") {
+		t.Fatalf("empty stderr left a dangling separator:\n%q", err.Error())
+	}
+}

--- a/internal/orchestrator/blocked_test.go
+++ b/internal/orchestrator/blocked_test.go
@@ -1,0 +1,168 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/xdlc-labs/xdlc-agent/internal/backlog"
+)
+
+// TestDecideNeverActsOnABlockedGate is the money assertion of issue
+// #45's second half. A gate that could not run is not a verdict about
+// the deployed software: dev-smoke fail routes to ActionFix, which pays
+// for a coding-agent run, and a prod-health breach routes to
+// ActionRevert, which pushes to prod. An unreachable ArgoCD or a typo'd
+// argocd_app must produce neither.
+func TestDecideNeverActsOnABlockedGate(t *testing.T) {
+	for _, src := range []Source{SourceCI, SourceDevGate, SourceProdHealth, Source("something-new")} {
+		s := Blocked(src, "svc", "dev-smoke", "abc1234", errors.New("gitops: argocd app get dev-typo: exit status 20"))
+		if got := Decide(s); got != ActionNoop {
+			t.Errorf("Decide(%s/blocked) = %s, want %s", src, got, ActionNoop)
+		}
+	}
+
+	// And the contrast: the same source and repo with a real verdict
+	// still acts, so "blocked" is not just a disabled gate.
+	if got := Decide(Signal{Source: SourceDevGate, Repo: "svc", Kind: KindFail}); got != ActionFix {
+		t.Errorf("dev-gate fail = %s, want %s", got, ActionFix)
+	}
+	if got := Decide(Signal{Source: SourceDevGate, Repo: "svc", Kind: KindPass}); got != ActionPromote {
+		t.Errorf("dev-gate pass = %s, want %s", got, ActionPromote)
+	}
+	if got := Decide(Signal{Source: SourceProdHealth, Repo: "svc", Kind: KindBreach}); got != ActionRevert {
+		t.Errorf("prod-health breach = %s, want %s", got, ActionRevert)
+	}
+}
+
+func TestBlockedCarriesTheReason(t *testing.T) {
+	s := Blocked(SourceDevGate, "svc", "dev-smoke", "abc1234",
+		errors.New(`gitops: argocd app get dev-typo: exit status 20: applications.argoproj.io "dev-typo" not found`))
+
+	if s.Kind != KindBlocked {
+		t.Fatalf("kind = %s", s.Kind)
+	}
+	if s.Evidence["escalate"] != EscalateGateUnavailable {
+		t.Fatalf("escalate = %v, want %s", s.Evidence["escalate"], EscalateGateUnavailable)
+	}
+	if s.Evidence["gate"] != "dev-smoke" {
+		t.Fatalf("gate = %v", s.Evidence["gate"])
+	}
+	reason, blocked := BlockedReason(s)
+	if !blocked {
+		t.Fatal("BlockedReason did not recognise a blocked signal")
+	}
+	if !strings.Contains(reason, `"dev-typo" not found`) {
+		t.Fatalf("reason lost the CLI's own diagnosis: %q", reason)
+	}
+
+	// A pass or a fail is never mistaken for one.
+	for _, k := range []Kind{KindPass, KindFail, KindBreach} {
+		if _, blocked := BlockedReason(Signal{Kind: k}); blocked {
+			t.Errorf("BlockedReason(%s) = blocked", k)
+		}
+	}
+	// Never empty, even if evidence was stripped.
+	if reason, _ := BlockedReason(Signal{Kind: KindBlocked}); reason == "" {
+		t.Fatal("blocked signal with no evidence produced an empty reason")
+	}
+}
+
+// TestBlockedGateIsRecordedForAnOperator: the whole point of routing it
+// through the orchestrator instead of returning an error. The record
+// has to reach BACKLOG.md and the audit callback, tagged so an operator
+// can tell it from both a pass and a fail — and no Dispatcher method
+// may be called.
+func TestBlockedGateIsRecordedForAnOperator(t *testing.T) {
+	blPath := filepath.Join(t.TempDir(), "BACKLOG.md")
+	bl, err := backlog.Open(blPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	disp := &fakeDispatcher{}
+	o := New(disp, bl, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	type audited struct {
+		s      Signal
+		action Action
+		err    error
+	}
+	auditCh := make(chan audited, 1)
+	o.Audit = func(s Signal, action Action, dispatchErr error, _ time.Time) error {
+		auditCh <- audited{s, action, dispatchErr}
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = o.Run(ctx) }()
+
+	o.Signals <- Blocked(SourceDevGate, "svc", "dev-smoke", "abc1234",
+		errors.New(`gitops: argocd app get dev-typo: exit status 20: applications.argoproj.io "dev-typo" not found`))
+
+	select {
+	case a := <-auditCh:
+		if a.action != ActionNoop {
+			t.Fatalf("action = %s, want %s — a blocked gate must not act", a.action, ActionNoop)
+		}
+		if a.s.Kind != KindBlocked {
+			t.Fatalf("audited kind = %s, want %s", a.s.Kind, KindBlocked)
+		}
+		if a.err != nil {
+			t.Fatalf("dispatchErr = %v; nothing was dispatched", a.err)
+		}
+		// The daemon's Audit func turns this into store.StatusError.
+		if _, blocked := BlockedReason(a.s); !blocked {
+			t.Fatal("audited signal is not recognisable as blocked")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for the audit record")
+	}
+
+	if len(disp.fixCalls)+len(disp.revertCalls)+len(disp.promoteCalls) != 0 {
+		t.Fatalf("dispatcher was called: fix=%d revert=%d promote=%d",
+			len(disp.fixCalls), len(disp.revertCalls), len(disp.promoteCalls))
+	}
+
+	raw, err := os.ReadFile(blPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := string(raw)
+	if !strings.Contains(line, "escalate="+EscalateGateUnavailable) {
+		t.Fatalf("BACKLOG.md has no escalate=%s:\n%s", EscalateGateUnavailable, line)
+	}
+	if !strings.Contains(line, "action=noop") {
+		t.Fatalf("BACKLOG.md action is not noop:\n%s", line)
+	}
+	if !strings.Contains(line, "dev-typo") {
+		t.Fatalf("BACKLOG.md does not say why the gate could not run:\n%s", line)
+	}
+}
+
+// TestBlockedGateDoesNotClearAProdBreach: a check that could not run
+// knows nothing about prod, so it must not re-arm Revert (or the
+// circuit breaker) by looking like a recovery.
+func TestBlockedGateDoesNotClearAProdBreach(t *testing.T) {
+	o := New(&fakeDispatcher{}, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	o.updateBreach(Signal{Source: SourceProdHealth, Repo: "svc", Kind: KindBreach})
+	if o.breachCount() != 1 {
+		t.Fatalf("breach not recorded")
+	}
+	o.updateBreach(Blocked(SourceProdHealth, "svc", "prod-health", "", errors.New("prometheus: connection refused")))
+	if o.breachCount() != 1 {
+		t.Fatal("a gate that could not run cleared the prod breach")
+	}
+	// A real pass still clears it.
+	o.updateBreach(Signal{Source: SourceProdHealth, Repo: "svc", Kind: KindPass})
+	if o.breachCount() != 0 {
+		t.Fatal("a real pass did not clear the breach")
+	}
+}

--- a/internal/orchestrator/decide.go
+++ b/internal/orchestrator/decide.go
@@ -16,6 +16,16 @@ const (
 // This is intentionally a pure function — easy to unit test, easy for
 // forks to swap out for their own policy.
 func Decide(s Signal) Action {
+	// A gate that could not run reported no verdict, so there is
+	// nothing to act on. This is checked before the Source switch, not
+	// inside each arm, so a new Source can never accidentally route
+	// "ArgoCD was unreachable" to Fix and pay for a coding-agent run
+	// against a repo that is not broken (issue #45). The record an
+	// operator sees is written by handle(), not by an Action.
+	if s.Kind == KindBlocked {
+		return ActionNoop
+	}
+
 	switch s.Source {
 	case SourceCI:
 		if s.Kind == KindFail {

--- a/internal/orchestrator/policy.go
+++ b/internal/orchestrator/policy.go
@@ -177,6 +177,10 @@ func (o *Orchestrator) updateBreach(s Signal) {
 		o.breach[s.Repo] = false
 		o.clearPatientZero(s.Repo)
 	}
+	// KindBlocked deliberately falls through: a gate that could not run
+	// knows nothing about prod, so it must neither raise nor clear a
+	// breach. Clearing one would silently re-arm Revert (and the circuit
+	// breaker) off a failed check.
 }
 
 func (o *Orchestrator) breachCount() int {

--- a/internal/orchestrator/signal.go
+++ b/internal/orchestrator/signal.go
@@ -20,7 +20,69 @@ const (
 	KindPass   Kind = "pass"
 	KindFail   Kind = "fail"
 	KindBreach Kind = "breach" // continuous threshold breach (prod-health)
+	// KindBlocked is "the gate could not run", which is not a verdict
+	// about the deployed software at all. A dead `argocd`, an expired
+	// session or a typo'd argocd_app leaves the gate with nothing to
+	// report, and before issue #45 that produced no Signal at all: the
+	// webhook answered 204, the poller logged, and Promote simply never
+	// fired again with no audit row and no BACKLOG.md line to say why.
+	//
+	// It is deliberately *not* KindFail. Decide maps a dev-gate fail to
+	// ActionFix, so a typo'd app name would spend a coding-agent run
+	// trying to fix a repo that is not broken. Every Source maps
+	// KindBlocked to ActionNoop; the visibility comes from the record
+	// the orchestrator writes on the way past — BACKLOG.md, the audit
+	// store, and from there `xdlc history`, /api/events and the console
+	// Activity feed, all tagged escalate=gate_unavailable.
+	KindBlocked Kind = "blocked"
 )
+
+// EscalateGateUnavailable is the evidence["escalate"] value on a
+// KindBlocked Signal, following the same convention as the fleet
+// policy's structural / circuit / root_cause / deps_pin reasons: the
+// one token an operator greps a BACKLOG.md or an Activity row for.
+const EscalateGateUnavailable = "gate_unavailable"
+
+// Blocked builds the Signal a gate runner emits when Gate.Check could
+// not produce a verdict. gateName and err are recorded as evidence so
+// the reason (not just the fact) reaches BACKLOG.md and the audit row;
+// sha is the commit the missing verdict would have applied to, and may
+// be empty.
+func Blocked(source Source, repo, gateName, sha string, err error) Signal {
+	reason := "gate check failed"
+	if err != nil {
+		reason = err.Error()
+	}
+	return Signal{
+		Source: source,
+		Repo:   repo,
+		Kind:   KindBlocked,
+		SHA:    sha,
+		At:     time.Now().UTC(),
+		Evidence: map[string]any{
+			"escalate":   EscalateGateUnavailable,
+			"gate":       gateName,
+			"gate_error": reason,
+		},
+	}
+}
+
+// BlockedReason reports whether s is a KindBlocked Signal and, if so,
+// why the gate could not run. Callers use it to record the signal as an
+// error rather than a successful noop — see the daemon's Audit func,
+// which sets store.StatusError so the row reads ok=false in
+// `xdlc history` and the console instead of looking like a clean pass.
+func BlockedReason(s Signal) (string, bool) {
+	if s.Kind != KindBlocked {
+		return "", false
+	}
+	if s.Evidence != nil {
+		if reason, _ := s.Evidence["gate_error"].(string); reason != "" {
+			return reason, true
+		}
+	}
+	return "gate could not run", true
+}
 
 // Signal is the unit of information flowing from gates back to the
 // orchestrator loop. Every gate check, webhook delivery, or poll tick

--- a/internal/poller/blocked_test.go
+++ b/internal/poller/blocked_test.go
@@ -1,0 +1,272 @@
+package poller
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/xdlc-labs/xdlc-agent/internal/gate"
+	"github.com/xdlc-labs/xdlc-agent/internal/orchestrator"
+)
+
+// erroringGate returns whatever error is currently set, so a test can
+// change the failure mode between ticks.
+type erroringGate struct {
+	mu    sync.Mutex
+	err   error
+	calls int
+}
+
+func (g *erroringGate) Name() string              { return "dev-smoke" }
+func (g *erroringGate) Trigger() gate.TriggerKind { return gate.OnSync }
+func (g *erroringGate) Check(context.Context, string) (gate.Result, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.calls++
+	if g.err != nil {
+		return gate.Result{}, g.err
+	}
+	return gate.Result{Status: gate.StatusPass}, nil
+}
+
+func (g *erroringGate) set(err error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.err = err
+}
+
+func drain(ch chan orchestrator.Signal) []orchestrator.Signal {
+	var out []orchestrator.Signal
+	for {
+		select {
+		case s := <-ch:
+			out = append(out, s)
+		default:
+			return out
+		}
+	}
+}
+
+// TestBlockedGateEmitsAnOperatorVisibleSignal: a dev-smoke gate whose
+// `argocd app get` failed used to produce no Signal at all — no audit
+// row, no BACKLOG.md line, nothing but a daemon log line — and Promote
+// simply never fired again (issue #45).
+func TestBlockedGateEmitsAnOperatorVisibleSignal(t *testing.T) {
+	eg := &erroringGate{err: errors.New(
+		`smoke gate: argocd health: gitops: argocd app get dev-typo: exit status 20: applications.argoproj.io "dev-typo" not found`)}
+	ch := make(chan orchestrator.Signal, 8)
+	var logs bytes.Buffer
+	p := &Poller{
+		Gate:    eg,
+		Repos:   []string{"svc"},
+		Source:  orchestrator.SourceDevGate,
+		Signals: ch,
+		Log:     slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		SHA:     func(context.Context, string) (string, error) { return "abc1234", nil },
+	}
+
+	p.tick(context.Background(), 30*time.Second)
+
+	got := drain(ch)
+	if len(got) != 1 {
+		t.Fatalf("emitted %d signals, want 1: %+v", len(got), got)
+	}
+	sig := got[0]
+	if sig.Kind != orchestrator.KindBlocked {
+		t.Fatalf("kind = %s, want %s", sig.Kind, orchestrator.KindBlocked)
+	}
+	// Distinguishable from a fail, and specifically not the kind that
+	// would spend a coding-agent run on a repo that is not broken.
+	if orchestrator.Decide(sig) != orchestrator.ActionNoop {
+		t.Fatalf("Decide = %s, want noop", orchestrator.Decide(sig))
+	}
+	if sig.Evidence["escalate"] != orchestrator.EscalateGateUnavailable {
+		t.Fatalf("escalate = %v", sig.Evidence["escalate"])
+	}
+	if sig.Evidence["gate"] != "dev-smoke" {
+		t.Fatalf("gate = %v", sig.Evidence["gate"])
+	}
+	reason, _ := sig.Evidence["gate_error"].(string)
+	if !strings.Contains(reason, `"dev-typo" not found`) {
+		t.Fatalf("evidence does not name the cause: %q", reason)
+	}
+	if sig.SHA != "abc1234" {
+		t.Fatalf("sha = %q, want the commit the missing verdict applied to", sig.SHA)
+	}
+	if !strings.Contains(logs.String(), "gate check failed") {
+		t.Fatalf("no operator-visible log line:\n%s", logs.String())
+	}
+}
+
+// TestBlockedGateDoesNotRepeatEveryTick is the log/backlog-flood guard.
+// The poller re-checks on every interval, so a permanently
+// misconfigured argocd_app would otherwise write an ERROR line, a
+// BACKLOG.md entry and an audit row per tick forever.
+func TestBlockedGateDoesNotRepeatEveryTick(t *testing.T) {
+	eg := &erroringGate{err: errors.New("gitops: argocd app get dev-typo: exit status 20")}
+	ch := make(chan orchestrator.Signal, 32)
+	var logs bytes.Buffer
+	p := &Poller{
+		Gate:    eg,
+		Repos:   []string{"svc"},
+		Source:  orchestrator.SourceDevGate,
+		Signals: ch,
+		Log:     slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelError})),
+	}
+
+	for i := 0; i < 10; i++ {
+		p.tick(context.Background(), 30*time.Second)
+	}
+	if got := len(drain(ch)); got != 1 {
+		t.Fatalf("10 ticks of the same failure emitted %d signals, want 1", got)
+	}
+	if n := strings.Count(logs.String(), "gate check failed"); n != 1 {
+		t.Fatalf("10 ticks of the same failure logged %d error lines, want 1:\n%s", n, logs.String())
+	}
+	if eg.calls != 10 {
+		t.Fatalf("gate was checked %d times, want 10 — suppression must not stop the polling", eg.calls)
+	}
+
+	// Recovery re-arms it, so a gate that breaks again later is
+	// reported again rather than staying silent for the process's life.
+	eg.set(nil)
+	p.tick(context.Background(), 30*time.Second)
+	if got := drain(ch); len(got) != 1 || got[0].Kind != orchestrator.KindPass {
+		t.Fatalf("recovery emitted %+v, want one pass", got)
+	}
+	eg.set(errors.New("gitops: argocd app get dev-typo: exit status 20"))
+	p.tick(context.Background(), 30*time.Second)
+	if got := drain(ch); len(got) != 1 || got[0].Kind != orchestrator.KindBlocked {
+		t.Fatalf("a gate that broke again emitted %+v, want one blocked", got)
+	}
+}
+
+// TestBlockedGateWithATimestampedReasonDoesNotFlood is the flood that
+// reason-equality alone does not stop, found against a stub `argocd`:
+// the real CLI stamps its own timestamp into the fatal line it prints,
+// so every tick produced a *different* reason string and wrote a record
+// per tick after all. A changed reason is held to one report per
+// BlockedRepeatWindow.
+func TestBlockedGateWithATimestampedReasonDoesNotFlood(t *testing.T) {
+	eg := &erroringGate{}
+	ch := make(chan orchestrator.Signal, 64)
+	var logs bytes.Buffer
+	p := &Poller{
+		Gate:    eg,
+		Repos:   []string{"svc"},
+		Source:  orchestrator.SourceDevGate,
+		Signals: ch,
+		Log:     slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelError})),
+	}
+
+	for i := 0; i < 20; i++ {
+		// What the stub (and the real CLI) actually prints.
+		eg.set(fmt.Errorf(
+			`gitops: argocd app get dev-typo: exit status 20: time=%q level=fatal msg="applications.argoproj.io \"dev-typo\" not found"`,
+			time.Now().Add(time.Duration(i)*time.Second).Format(time.RFC3339)))
+		p.tick(context.Background(), 30*time.Second)
+	}
+	if got := len(drain(ch)); got != 1 {
+		t.Fatalf("20 ticks of a timestamped reason emitted %d signals, want 1", got)
+	}
+	if n := strings.Count(logs.String(), "gate check failed"); n != 1 {
+		t.Fatalf("20 ticks of a timestamped reason logged %d error lines, want 1", n)
+	}
+}
+
+// TestBlockedGateReportsAGenuinelyNewFailureMode: the window must not
+// swallow a different cause forever — the app name was fixed and now
+// the session has expired is a new thing for an operator to see.
+func TestBlockedGateReportsAGenuinelyNewFailureMode(t *testing.T) {
+	eg := &erroringGate{err: errors.New("gitops: argocd app get dev-typo: exit status 20")}
+	ch := make(chan orchestrator.Signal, 8)
+	p := &Poller{
+		Gate:    eg,
+		Repos:   []string{"svc"},
+		Source:  orchestrator.SourceDevGate,
+		Signals: ch,
+		Log:     silentLogger(),
+		// The window has elapsed by the time the reason changes.
+		BlockedRepeatWindow: time.Nanosecond,
+	}
+
+	p.tick(context.Background(), 30*time.Second)
+	if got := len(drain(ch)); got != 1 {
+		t.Fatalf("first failure emitted %d signals, want 1", got)
+	}
+	// Same reason: still suppressed, window or no window.
+	p.tick(context.Background(), 30*time.Second)
+	if got := len(drain(ch)); got != 0 {
+		t.Fatalf("the identical reason re-emitted %d signals", got)
+	}
+
+	eg.set(errors.New("gitops: argocd app get dev-svc: exit status 20: token has expired"))
+	p.tick(context.Background(), 30*time.Second)
+	got := drain(ch)
+	if len(got) != 1 {
+		t.Fatalf("a new failure mode emitted %d signals, want 1", len(got))
+	}
+	if reason, _ := got[0].Evidence["gate_error"].(string); !strings.Contains(reason, "token has expired") {
+		t.Fatalf("second episode carried the first reason: %q", reason)
+	}
+}
+
+// TestBlockedGateDoesNotDisturbTheVerdictEdge: recording "blocked" in
+// the verdict edge state would make the next real verdict look like a
+// transition, so a sustained prod-health breach interrupted by one
+// failed check would emit a second breach — and revert the revert.
+func TestBlockedGateDoesNotDisturbTheVerdictEdge(t *testing.T) {
+	fg := &fakeGate{results: map[string]gate.Result{"svc": {Status: gate.StatusFail}}}
+	ch := make(chan orchestrator.Signal, 8)
+	p := &Poller{
+		Gate:    fg,
+		Repos:   []string{"svc"},
+		Source:  orchestrator.SourceProdHealth,
+		Signals: ch,
+		Log:     silentLogger(),
+	}
+
+	p.tick(context.Background(), 30*time.Second) // breach → one Revert
+	if got := drain(ch); len(got) != 1 || got[0].Kind != orchestrator.KindBreach {
+		t.Fatalf("first tick emitted %+v, want one breach", got)
+	}
+
+	fg.errs = map[string]error{"svc": errors.New("promclient: connection refused")}
+	p.tick(context.Background(), 30*time.Second) // gate cannot run
+	if got := drain(ch); len(got) != 1 || got[0].Kind != orchestrator.KindBlocked {
+		t.Fatalf("blocked tick emitted %+v, want one blocked", got)
+	}
+
+	fg.errs = nil
+	p.tick(context.Background(), 30*time.Second) // still breaching
+	if got := drain(ch); len(got) != 0 {
+		t.Fatalf("the same sustained breach re-emitted after a blocked tick: %+v — that reverts the revert", got)
+	}
+}
+
+// TestCancelledCheckIsNotABlockedGate: a tick deadline or a daemon
+// shutdown says nothing about the gate's configuration, and tick()
+// already reports an overrun itself. Emitting a record per timed-out
+// tick would be the flood in a different costume.
+func TestCancelledCheckIsNotABlockedGate(t *testing.T) {
+	hg := &hangingGate{name: "prod-health"}
+	ch := make(chan orchestrator.Signal, 4)
+	p := &Poller{
+		Gate:    hg,
+		Repos:   []string{"svc"},
+		Source:  orchestrator.SourceProdHealth,
+		Signals: ch,
+		Log:     silentLogger(),
+		Timeout: 20 * time.Millisecond,
+	}
+	p.tick(context.Background(), time.Second)
+	if got := drain(ch); len(got) != 0 {
+		t.Fatalf("a timed-out tick emitted %+v, want nothing", got)
+	}
+}

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -62,9 +62,39 @@ type Poller struct {
 	// a tick is always finished (or cancelled) before the next is due.
 	Timeout time.Duration
 
+	// BlockedRepeatWindow bounds how often one repo's "gate could not
+	// run" is re-reported when the reason *text* changes between ticks.
+	// 0 → defaultBlockedRepeatWindow. See blockedEpisode.
+	BlockedRepeatWindow time.Duration
+
 	mu   sync.Mutex
 	last map[string]edgeState // repo → last emitted Kind + SHA
+
+	// blockedMu guards blocked, the "gate could not run" episode per
+	// repo. See blockedEpisode.
+	blockedMu sync.Mutex
+	blocked   map[string]blockedState
 }
+
+// blockedState is the "gate could not run" episode a repo is currently
+// in: the reason already reported, and when it was reported.
+type blockedState struct {
+	reason string
+	at     time.Time
+}
+
+// defaultBlockedRepeatWindow is how long a repo stays quiet after a
+// "gate could not run" record, even if the reason text changes.
+//
+// Reason equality alone is not enough, because real CLI diagnostics are
+// not stable strings: `argocd` prefixes its fatal line with its own
+// timestamp, so a permanently misconfigured argocd_app produced a
+// *different* reason every tick and wrote a record per tick after all
+// (measured against a stub argocd). An hour is long enough that a dead
+// gate cannot flood a BACKLOG.md, and short enough that an operator who
+// starts looking later still finds a recent record rather than one
+// buried at daemon start.
+const defaultBlockedRepeatWindow = time.Hour
 
 // edgeState is what a repo last emitted, and so what a new tick has to
 // differ from to emit again.
@@ -188,13 +218,41 @@ func (p *Poller) checkOne(ctx context.Context, repo string) {
 
 	result, err := p.Gate.Check(ctx, repo)
 	if err != nil {
-		p.Log.Error("poller: gate check failed", "gate", p.Gate.Name(), "repo", repo, "error", err)
+		// Counted on every tick: the counter is the continuous,
+		// alertable view of "this gate is not running", and a counter
+		// cannot flood. The human-readable channels below are
+		// edge-triggered instead.
 		if p.Metrics != nil {
 			p.Metrics.GateChecks.Add(ctx, 1, metric.WithAttributes(
 				otel.AttrGate(p.Gate.Name()), otel.AttrStatus("error")))
 		}
+		if ctx.Err() != nil {
+			// The tick deadline (or a daemon shutdown) cancelled the
+			// check, so the error says nothing about the gate's own
+			// configuration. tick() reports an overrun itself, at
+			// ERROR, on every tick — that is the issue #42 signal — and
+			// the tick context is already dead, so there is nothing
+			// left to carry a Signal.
+			p.Log.Error("poller: gate check failed", "gate", p.Gate.Name(), "repo", repo, "error", err)
+			return
+		}
+		if !p.blockedEpisode(repo, err.Error()) {
+			// Same failure as last tick. A permanently misconfigured
+			// argocd_app must not write one of these per interval
+			// forever.
+			p.Log.Debug("poller: gate still cannot run",
+				"gate", p.Gate.Name(), "repo", repo, "error", err)
+			return
+		}
+		p.Log.Error("poller: gate check failed", "gate", p.Gate.Name(), "repo", repo, "error", err)
+		// A gate that cannot run is not a failing gate: emitting
+		// KindFail here would route dev-smoke to ActionFix and pay a
+		// coding agent to fix a repo that is not broken. KindBlocked is
+		// ActionNoop plus an operator-visible record (issue #45).
+		p.Signals <- orchestrator.Blocked(p.Source, repo, p.Gate.Name(), sha, err)
 		return
 	}
+	p.clearBlocked(repo)
 
 	kind := orchestrator.KindPass
 	status := "pass"
@@ -223,6 +281,57 @@ func (p *Poller) checkOne(ctx context.Context, repo string) {
 		Evidence: result.Evidence,
 		At:       time.Now(),
 	}
+}
+
+// blockedEpisode reports whether this "gate could not run" is new
+// enough to be worth telling an operator about, and remembers it when
+// it is.
+//
+// The poller re-checks every interval, so without this a typo'd
+// argocd_app would write an ERROR log line, a BACKLOG.md entry and an
+// audit row every tick for the lifetime of the process.
+//
+// Two guards, because either one alone leaks. An identical reason is
+// never re-reported, which covers the common case. But a reason is a
+// CLI's diagnostic, not a stable key — `argocd` stamps its own
+// timestamp into the fatal line it prints — so a changed reason is also
+// held to one report per BlockedRepeatWindow. That keeps a *genuinely*
+// different failure (the app name was fixed and now the session has
+// expired) visible, without letting a noisy message reinstate the
+// per-tick flood.
+//
+// It deliberately keeps its own state instead of using the verdict edge
+// (p.last). Recording "blocked" there would make the next real verdict
+// look like a transition, so a sustained prod-health breach interrupted
+// by one failed check would emit a second breach and revert the revert.
+// A recovered check clears the episode (clearBlocked), so a gate that
+// breaks again later is reported again.
+func (p *Poller) blockedEpisode(repo, reason string) bool {
+	window := p.BlockedRepeatWindow
+	if window <= 0 {
+		window = defaultBlockedRepeatWindow
+	}
+	p.blockedMu.Lock()
+	defer p.blockedMu.Unlock()
+	if p.blocked == nil {
+		p.blocked = make(map[string]blockedState)
+	}
+	now := time.Now()
+	if prev, ok := p.blocked[repo]; ok {
+		if prev.reason == reason || now.Sub(prev.at) < window {
+			return false
+		}
+	}
+	p.blocked[repo] = blockedState{reason: reason, at: now}
+	return true
+}
+
+// clearBlocked forgets repo's blocked episode after a Check that
+// actually returned a verdict, re-arming the report for the next break.
+func (p *Poller) clearBlocked(repo string) {
+	p.blockedMu.Lock()
+	defer p.blockedMu.Unlock()
+	delete(p.blocked, repo)
 }
 
 // edge returns true if kind — or, when SHA resolution is wired, the

--- a/internal/poller/poller_test.go
+++ b/internal/poller/poller_test.go
@@ -74,8 +74,12 @@ func TestPollerTick(t *testing.T) {
 	if got["repo-fail"] != orchestrator.KindBreach {
 		t.Errorf("repo-fail kind = %v, want %v", got["repo-fail"], orchestrator.KindBreach)
 	}
-	if _, ok := got["repo-err"]; ok {
-		t.Errorf("repo-err should not emit a signal (Check errored), got %v", got["repo-err"])
+	// A Check that errored has no verdict. It used to emit nothing at
+	// all, which left a typo'd argocd_app invisible outside the daemon
+	// log (issue #45); it now emits KindBlocked, which is ActionNoop —
+	// never the KindBreach/KindFail that would revert or Fix.
+	if got["repo-err"] != orchestrator.KindBlocked {
+		t.Errorf("repo-err kind = %v, want %v", got["repo-err"], orchestrator.KindBlocked)
 	}
 	if len(fg.calls) != 3 {
 		t.Errorf("expected 3 Check calls, got %d: %v", len(fg.calls), fg.calls)

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -5,7 +5,9 @@ package validate
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -148,10 +150,10 @@ func Config(cfg *config.Config) []Issue {
 		}
 
 		if hasGate(r, "dev-smoke") {
-			if resolveArgoCDApp(cfg, r) == "" {
+			if ResolveArgoCDApp(cfg, r) == "" {
 				issues = append(issues, Issue{Repo: r.Name, Message: "dev-smoke gate configured but no argocd_app (repo or gates.dev-smoke default)"})
 			}
-			if resolveProbeJob(cfg, r) == "" {
+			if ResolveProbeJob(cfg, r) == "" {
 				issues = append(issues, Issue{Repo: r.Name, Message: "dev-smoke gate configured but no probe_job (repo or gates.dev-smoke default)"})
 			}
 		}
@@ -286,9 +288,25 @@ func GitOps(cfg *config.Config, gitopsDir string) ([]Issue, error) {
 	if strings.TrimSpace(gitopsDir) == "" {
 		return nil, nil // optional — full gitops tree lives outside this repo
 	}
-	appNames, err := applicationNames(filepath.Join(gitopsDir, "apps", "dev"))
+	appsDev := filepath.Join(gitopsDir, "apps", "dev")
+	// Guard before reading, the way RoleNamespace guards before
+	// comparing: a GitOps tree that simply does not use the apps/dev
+	// layout is a *finding about the config*, not a reason to abort the
+	// command. Reading first turned it into a returned error, which
+	// `validate` and `doctor` both surface as a cobra usage dump instead
+	// of the one-line issue every other check produces (issue #45).
+	if _, err := os.Stat(appsDev); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return []Issue{{Message: fmt.Sprintf(
+				"--gitops-dir %s has no %s directory, so no ArgoCD Application manifests could be "+
+					"cross-checked against argocd_app; point it at the root of a tree laid out as "+
+					"apps/dev/<app>.yaml, or drop the flag", gitopsDir, filepath.Join("apps", "dev"))}}, nil
+		}
+		return nil, fmt.Errorf("validate: reading %s: %w", appsDev, err)
+	}
+	appNames, err := applicationNames(appsDev)
 	if err != nil {
-		return nil, fmt.Errorf("validate: reading %s: %w", filepath.Join(gitopsDir, "apps", "dev"), err)
+		return nil, fmt.Errorf("validate: reading %s: %w", appsDev, err)
 	}
 
 	var issues []Issue
@@ -296,7 +314,7 @@ func GitOps(cfg *config.Config, gitopsDir string) ([]Issue, error) {
 		if !hasGate(r, "dev-smoke") {
 			continue
 		}
-		app := resolveArgoCDApp(cfg, r)
+		app := ResolveArgoCDApp(cfg, r)
 		if app == "" {
 			continue // already reported by Config()
 		}
@@ -308,14 +326,27 @@ func GitOps(cfg *config.Config, gitopsDir string) ([]Issue, error) {
 	return issues, nil
 }
 
-func resolveArgoCDApp(cfg *config.Config, r config.Repo) string {
+// ResolveArgoCDApp returns the ArgoCD Application name r's dev-smoke
+// gate will actually be built with: the repo's own argocd_app, falling
+// back to the shared gates.dev-smoke.argocd_app. Exported because
+// gatebuild.DevSmoke (which builds the gate) and `xdlc doctor` (which
+// decides whether the `argocd` binary is required) have to answer the
+// same question the same way. doctor used to read r.ArgoCDApp alone, so
+// two semantically identical configs — one naming the app per repo, one
+// sharing it under gates.dev-smoke — got opposite verdicts, and doctor
+// green-lit a config whose dev-smoke gate could not run (issue #45).
+func ResolveArgoCDApp(cfg *config.Config, r config.Repo) string {
 	if r.ArgoCDApp != "" {
 		return r.ArgoCDApp
 	}
 	return cfg.Gates.DevSmoke.ArgoCDApp
 }
 
-func resolveProbeJob(cfg *config.Config, r config.Repo) string {
+// ResolveProbeJob returns the probe Job name r's dev-smoke gate will be
+// built with — the repo's own probe_job, falling back to the shared
+// gates.dev-smoke.probe_job. Same single-source-of-truth reason as
+// ResolveArgoCDApp.
+func ResolveProbeJob(cfg *config.Config, r config.Repo) string {
 	if r.ProbeJob != "" {
 		return r.ProbeJob
 	}

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -456,3 +456,76 @@ func hasIssueContaining(issues []Issue, want string) bool {
 	}
 	return false
 }
+
+// TestGitOpsMissingAppsDevReportsAnIssue: pointing --gitops-dir at a
+// tree that does not use the apps/dev layout used to hard-error, which
+// cobra turns into a usage dump instead of the one-line issue every
+// other check produces (issue #45). It is a finding about the config,
+// not a reason to abort the command — the same shape RoleNamespace has.
+func TestGitOpsMissingAppsDevReportsAnIssue(t *testing.T) {
+	cfg := &config.Config{
+		Repos: []config.Repo{
+			{Name: "svc", GitHub: "org/svc", Gates: []string{"dev-smoke"}, ArgoCDApp: "dev-svc", ProbeJob: "smoke-e2e"},
+		},
+	}
+
+	// A real directory that simply has no apps/dev in it.
+	issues, err := GitOps(cfg, t.TempDir())
+	if err != nil {
+		t.Fatalf("GitOps returned an error instead of an issue: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("expected exactly 1 issue, got %v", issues)
+	}
+	if !strings.Contains(issues[0].Message, filepath.Join("apps", "dev")) {
+		t.Errorf("issue does not name the missing directory: %q", issues[0].Message)
+	}
+
+	// And a --gitops-dir that does not exist at all.
+	issues, err = GitOps(cfg, filepath.Join(t.TempDir(), "no-such-tree"))
+	if err != nil {
+		t.Fatalf("GitOps returned an error instead of an issue: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("expected exactly 1 issue, got %v", issues)
+	}
+
+	// An empty flag is still "not configured", not an issue.
+	if issues, err := GitOps(cfg, ""); err != nil || issues != nil {
+		t.Fatalf("empty gitops-dir = (%v, %v), want (nil, nil)", issues, err)
+	}
+}
+
+// TestResolveArgoCDAppSharesTheFallback pins the one resolver
+// gatebuild.DevSmoke, validate and `xdlc doctor` all read, so the app
+// doctor tests for is the app the gate is built with (issue #45).
+func TestResolveArgoCDAppSharesTheFallback(t *testing.T) {
+	shared := &config.Config{Repos: []config.Repo{{Name: "svc"}}}
+	shared.Gates.DevSmoke.ArgoCDApp = "dev-svc"
+	shared.Gates.DevSmoke.ProbeJob = "smoke-e2e"
+	perRepo := &config.Config{
+		Repos: []config.Repo{{Name: "svc", ArgoCDApp: "dev-svc", ProbeJob: "smoke-e2e"}},
+	}
+
+	for _, c := range []struct {
+		name string
+		cfg  *config.Config
+	}{
+		{"shared default", shared},
+		{"per-repo override", perRepo},
+	} {
+		if got := ResolveArgoCDApp(c.cfg, c.cfg.Repos[0]); got != "dev-svc" {
+			t.Errorf("%s: ResolveArgoCDApp = %q, want dev-svc", c.name, got)
+		}
+		if got := ResolveProbeJob(c.cfg, c.cfg.Repos[0]); got != "smoke-e2e" {
+			t.Errorf("%s: ResolveProbeJob = %q, want smoke-e2e", c.name, got)
+		}
+	}
+
+	// The per-repo value wins when both are set.
+	both := &config.Config{Repos: []config.Repo{{Name: "svc", ArgoCDApp: "dev-mine"}}}
+	both.Gates.DevSmoke.ArgoCDApp = "dev-shared"
+	if got := ResolveArgoCDApp(both, both.Repos[0]); got != "dev-mine" {
+		t.Errorf("ResolveArgoCDApp = %q, want the per-repo dev-mine", got)
+	}
+}

--- a/internal/webhook/github.go
+++ b/internal/webhook/github.go
@@ -369,6 +369,15 @@ type argoCDNotification struct {
 // Without both of those wired, this path emits no signal at all and the
 // poller remains the only route to a promote: losing webhook latency is
 // strictly better than promoting on an unverified claim.
+//
+// A CheckSmoke that *errors* is a third outcome, distinct from pass and
+// fail: the gate could not run. It emits KindBlocked (202) rather than
+// the old bare 204, so the delivery leaves a BACKLOG.md line and an
+// audit row saying why — see orchestrator.KindBlocked. 202 rather than
+// a 5xx on purpose: an ArgoCD notification is not a retry queue this
+// daemon wants to drive, and the record has already been written, so
+// asking the notification controller to redeliver would only multiply
+// it.
 func (s *Server) handleArgoCD(w http.ResponseWriter, r *http.Request) {
 	if !s.allow(w) {
 		return
@@ -433,8 +442,19 @@ func (s *Server) handleArgoCD(w http.ResponseWriter, r *http.Request) {
 
 	passed, gateEvidence, err := s.CheckSmoke(ctx, repo)
 	if err != nil {
-		s.Log.Error("argocd webhook: smoke check failed", "repo", repo, "error", err)
-		w.WriteHeader(http.StatusNoContent)
+		// The gate could not run, which is not the same as the gate
+		// failing: answering with KindFail would route dev-smoke to
+		// ActionFix and pay a coding agent to fix a repo that is not
+		// broken. Emit KindBlocked instead — ActionNoop, but with a
+		// BACKLOG.md line and an audit row naming the reason, so a
+		// typo'd argocd_app is no longer invisible outside the daemon
+		// log (issue #45).
+		s.Log.Error("argocd webhook: smoke check could not run", "repo", repo, "app", app, "error", err)
+		blocked := orchestrator.Blocked(orchestrator.SourceDevGate, repo, "dev-smoke", sha, err)
+		blocked.Evidence["argocd_app"] = app
+		blocked.Evidence["via"] = "webhook+probe"
+		s.emit(blocked, "argocd")
+		w.WriteHeader(http.StatusAccepted)
 		return
 	}
 

--- a/internal/webhook/github_test.go
+++ b/internal/webhook/github_test.go
@@ -408,13 +408,6 @@ func TestHandleArgoCDSyncAloneDoesNotPromote(t *testing.T) {
 			wantKind:   orchestrator.KindPass,
 		},
 		{
-			name: "probe errored: no signal",
-			check: func(context.Context, string) (bool, map[string]any, error) {
-				return false, nil, errors.New("kubectl: connection refused")
-			},
-			wantStatus: http.StatusNoContent,
-		},
-		{
 			name: "unattributable commit: no signal",
 			check: func(context.Context, string) (bool, map[string]any, error) {
 				return true, nil, nil
@@ -1005,5 +998,52 @@ func TestHandleGitHubMatchingBranchDoesNotWarn(t *testing.T) {
 	}
 	if strings.Contains(logs.String(), "branch mismatch") {
 		t.Errorf("matching branch must not warn:\n%s", logs.String())
+	}
+}
+
+// TestHandleArgoCDGateThatCannotRunIsVisibleButNotAFail: the webhook leg
+// of issue #45. A CheckSmoke error used to answer 204 and emit nothing,
+// so a typo'd argocd_app produced no signal, no audit row and no
+// BACKLOG.md entry — Promote just never fired again. It now emits
+// KindBlocked, which records the reason without being mistaken for a
+// fail (a dev-gate fail is ActionFix, i.e. a paid coding-agent run).
+func TestHandleArgoCDGateThatCannotRunIsVisibleButNotAFail(t *testing.T) {
+	ch := make(chan orchestrator.Signal, 1)
+	srv := argoServer(ch)
+	srv.CheckSmoke = func(context.Context, string) (bool, map[string]any, error) {
+		return false, nil, errors.New(
+			`smoke gate: argocd health: gitops: argocd app get dev-typo: exit status 20: applications.argoproj.io "dev-typo" not found`)
+	}
+
+	if got := postArgoCD(t, srv, syncedHealthy); got != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", got, http.StatusAccepted)
+	}
+
+	select {
+	case sig := <-ch:
+		if sig.Kind != orchestrator.KindBlocked {
+			t.Fatalf("kind = %s, want %s", sig.Kind, orchestrator.KindBlocked)
+		}
+		if sig.Source != orchestrator.SourceDevGate {
+			t.Fatalf("source = %s", sig.Source)
+		}
+		if got := orchestrator.Decide(sig); got != orchestrator.ActionNoop {
+			t.Fatalf("Decide = %s, want %s — an unreachable ArgoCD must not buy a Fix", got, orchestrator.ActionNoop)
+		}
+		if sig.Evidence["escalate"] != orchestrator.EscalateGateUnavailable {
+			t.Fatalf("escalate = %v", sig.Evidence["escalate"])
+		}
+		if sig.Evidence["argocd_app"] != "dev-example-service" {
+			t.Fatalf("evidence does not name the app the notification was for: %v", sig.Evidence)
+		}
+		reason, _ := sig.Evidence["gate_error"].(string)
+		if !strings.Contains(reason, `"dev-typo" not found`) {
+			t.Fatalf("evidence does not say why the gate could not run: %q", reason)
+		}
+		if sig.SHA != testSHA {
+			t.Fatalf("sha = %q, want the tip read before the probe (%s)", sig.SHA, testSHA)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no signal emitted: the gate failure is still invisible")
 	}
 }


### PR DESCRIPTION
Fixes #45, found against a real ArgoCD while verifying #25. Also folds the six opt-in fixes from #46 into the untagged `0.0.1-beta.5` changelog section, so one tag ships everything.

**The bug.** A typo'd `argocd_app` killed the promote gate in total silence. Two causes compounded:

- The ArgoCD CLI's stderr was discarded, so a wrong app name, an expired session, a missing kubeconfig and an RBAC denial were all indistinguishable `exit status 20`.
- The smoke gate returned an error rather than a verdict, so the webhook answered 204 and the poller only logged. No signal, no audit row, no `BACKLOG.md` line. Promote then never fired again with nothing anywhere saying why.

**The fix.** Stderr is carried into the error, collapsed to one line and truncated, since it lands in gate evidence and an audit row. A gate that could not run emits a distinct `blocked` signal recorded with `escalate=gate_unavailable` plus the underlying reason, so it reaches `BACKLOG.md`, the audit store, `xdlc history`, the SSE feed and the console Activity list.

**It is deliberately not a fail.** `Decide` maps `blocked` to a noop *before* the source switch rather than inside each arm, so no future source can route "ArgoCD was unreachable" to `ActionFix` and spend a coding-agent run against a repo that is not broken. A fail is a verdict about the deployed software; this is the absence of one.

**Repeat suppression.** The poller re-checks every interval and would otherwise write a record per tick forever. Reason equality alone was not enough — `argocd` prefixes its fatal line with its own timestamp, so the text differs every tick — so there is a time window too. The webhook path still records once per delivery, since each delivery is a real event rather than a re-check.

**Measured against a stub `argocd` that exits 20 with a `NotFound` on stderr**, old binary versus new:

| | old (`main`) | new |
|---|---|---|
| webhook response | 204 | 202 |
| the actual cause in the log | absent (`exit status 20`) | `rpc error: code = NotFound desc = applications.argoproj.io "dev-typo-app" not found` |
| `BACKLOG.md` rows | 0 | 1, with `escalate=gate_unavailable` |
| audit rows | 0 | 1, `kind=blocked action=noop` |
| 8 poller ticks, broken app | n/a | 1 record, not 8 |

**Also from #45:**

- `doctor` no longer green-lights a config whose dev-smoke gate cannot run. It checked only `repos[].argocd_app` and ignored the `gates.dev-smoke.argocd_app` fallback that `gatebuild` and `validate` both honour, so two semantically identical configs got opposite verdicts with `argocd` off PATH. All three now share one resolver. Verified: old gives `[FAIL]` and `[ok]` for the two shapes, new gives `[FAIL]` for both.
- `validate --gitops-dir` reports an issue instead of aborting with a cobra usage dump when the tree has no `apps/dev`, matching how the role-namespace check already behaved.

**Checklist**
- [x] `make build && make test && make lint` clean (`go test -race`, all 25 packages; `golangci-lint` 0 issues)
- [x] `test -z "$(gofmt -l cmd internal)"`
- [x] New/changed behavior documented (`CHANGELOG.md`, code comments)
- [x] UI not touched, so the go:embed console is left alone
- [x] Vendor-specific logic stays behind the existing interfaces: the stderr capture is inside `internal/gitops`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
