### PR TITLE
Stop a vanished metric series from reading as healthy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A vanished metric series read as perfectly healthy, silently disabling breach detection** (#48). `promclient.Query` returned `0, nil` for a query that matched no series, and the prod-health gate fails only when a value exceeds its threshold, so no data always passed. If a series stopped existing — metric renamed, exporter down, a relabel change, a typo in `p95_query` or `error_rate_query` — the gate reported healthy at the exact moment its inputs broke, and the poller's edge trigger *cleared* any breach already live. Since this gate's action is Revert, that is the dangerous direction to fail in. An empty result set is now `promclient.ErrNoData`, which the gate turns into no verdict at all and therefore a `blocked` signal (`escalate=gate_unavailable`, mapped to a noop), naming which of the two queries came back empty and telling the operator to check the metric, its exporter and any relabelling. A genuine zero from a series that really exists is still a pass, and a transport failure keeps its own wording so the timeout case is not mislabelled as no-data. A caller that wants zero for an absent series can still have it, but has to say so
+
 ## [0.0.1-beta.5] - 2026-09-08
 
 This release exists because verifying the open adoption issues turned the daemon's own

--- a/internal/gate/prodhealth.go
+++ b/internal/gate/prodhealth.go
@@ -2,8 +2,11 @@ package gate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/xdlc-labs/xdlc-agent/internal/promclient"
 )
 
 // RepoThresholds is an optional per-repo override of the gate's default
@@ -29,7 +32,10 @@ type ProdHealthGate struct {
 	// use P95ThresholdMS / ErrorRateThresh.
 	RepoThresholds map[string]RepoThresholds
 
-	// Query runs a PromQL query and returns the scalar result.
+	// Query runs a PromQL query and returns the scalar result. An error
+	// — including promclient.ErrNoData for a query that matched no
+	// series — makes Check return no verdict at all, which the runners
+	// turn into an orchestrator.Blocked signal.
 	Query func(ctx context.Context, promQL string) (float64, error)
 
 	P95Query       string
@@ -51,11 +57,11 @@ func (g *ProdHealthGate) Check(ctx context.Context, repo string) (Result, error)
 
 	p95, err := g.Query(ctx, p95Q)
 	if err != nil {
-		return Result{}, fmt.Errorf("prod-health gate: p95 query: %w", err)
+		return Result{}, queryErr("p95_query", err)
 	}
 	errRate, err := g.Query(ctx, errQ)
 	if err != nil {
-		return Result{}, fmt.Errorf("prod-health gate: error-rate query: %w", err)
+		return Result{}, queryErr("error_rate_query", err)
 	}
 
 	status := StatusPass
@@ -75,6 +81,28 @@ func (g *ProdHealthGate) Check(ctx context.Context, repo string) (Result, error)
 			"error_rate_query":  errQ,
 		},
 	}, nil
+}
+
+// queryErr wraps a failed metrics query, naming the config key that
+// produced it so an operator reading a BACKLOG.md line, an audit row or
+// the console Activity feed knows which of the two queries to go and
+// look at.
+//
+// A query that matched no series gets its own wording, because the
+// operator's next move is different: nothing needs to be wrong with the
+// service for this to happen, and the thing to inspect is the query or
+// the exporter behind it. Either way it is an error and not a verdict,
+// so the runner emits orchestrator.Blocked (escalate=gate_unavailable,
+// mapped to a noop) rather than a pass. Reporting a pass here is the
+// issue #48 bug: no data used to arrive as p95=0 / error_rate=0, which
+// this gate reads as healthy, silently disabling breach detection and
+// clearing any breach already live.
+func queryErr(key string, err error) error {
+	if errors.Is(err, promclient.ErrNoData) {
+		return fmt.Errorf("prod-health gate: %s matched no series, so prod health is unknown, not healthy: "+
+			"check the metric name, its exporter, and any relabelling before trusting this gate again: %w", key, err)
+	}
+	return fmt.Errorf("prod-health gate: %s: %w", key, err)
 }
 
 func (g *ProdHealthGate) thresholdsFor(repo string) (p95MS, errRate float64) {

--- a/internal/gate/prodhealth_test.go
+++ b/internal/gate/prodhealth_test.go
@@ -2,7 +2,12 @@ package gate
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/xdlc-labs/xdlc-agent/internal/promclient"
 )
 
 func TestProdHealthExpandsRepoPlaceholder(t *testing.T) {
@@ -82,5 +87,130 @@ func TestProdHealthPerRepoThresholds(t *testing.T) {
 	}
 	if res.Evidence["p95_threshold_ms"] != 500.0 {
 		t.Fatalf("other threshold = %v", res.Evidence["p95_threshold_ms"])
+	}
+}
+
+// noData is what promclient.Query returns for a query that matched no
+// series: the sentinel, wrapped with the PromQL text.
+func noData(promQL string) error {
+	return fmt.Errorf("promclient: %w: %q", promclient.ErrNoData, promQL)
+}
+
+// TestProdHealthNoDataBlocksInsteadOfPassing is the issue #48 case. The
+// gate fails only on value > threshold, so a query returning 0 always
+// passed — and before this fix a vanished series (metric renamed,
+// exporter down, relabelled away, typo in the query) arrived as 0. The
+// gate reported healthy, and the poller's edge trigger then cleared any
+// breach already live: breach detection silently switched off at the
+// exact moment its inputs broke.
+//
+// Check must return an error instead, which the runners turn into an
+// orchestrator.Blocked signal (escalate=gate_unavailable, ActionNoop) -
+// unknown, neither pass nor fail.
+func TestProdHealthNoDataBlocksInsteadOfPassing(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		empty   string // the query that matched nothing
+		wantKey string // config key the error must name
+	}{
+		{name: "p95", empty: "p95", wantKey: "p95_query"},
+		{name: "error rate", empty: "err", wantKey: "error_rate_query"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &ProdHealthGate{
+				P95ThresholdMS:  500,
+				ErrorRateThresh: 0.01,
+				P95Query:        "p95",
+				ErrorRateQuery:  "err",
+				Query: func(_ context.Context, q string) (float64, error) {
+					if q == tc.empty {
+						return 0, noData(q)
+					}
+					return 1, nil
+				},
+			}
+
+			res, err := g.Check(context.Background(), "api")
+			if err == nil {
+				t.Fatalf("no data reported a verdict: status=%v evidence=%v", res.Status, res.Evidence)
+			}
+			if res.Status == StatusPass {
+				t.Fatalf("no data returned StatusPass alongside its error")
+			}
+			if !errors.Is(err, promclient.ErrNoData) {
+				t.Fatalf("error does not wrap promclient.ErrNoData: %v", err)
+			}
+			// The text reaches BACKLOG.md, an audit row and the console
+			// Activity feed. An operator must be able to tell which of
+			// the two queries broke, and that the service itself is not
+			// being accused of anything.
+			msg := err.Error()
+			for _, want := range []string{tc.wantKey, "matched no series", "unknown, not healthy", "exporter"} {
+				if !strings.Contains(msg, want) {
+					t.Errorf("error text missing %q: %v", want, msg)
+				}
+			}
+			if other := map[string]string{"p95_query": "error_rate_query", "error_rate_query": "p95_query"}[tc.wantKey]; strings.Contains(msg, other) {
+				t.Errorf("error text blames %q as well as %q: %v", other, tc.wantKey, msg)
+			}
+		})
+	}
+}
+
+// TestProdHealthGenuineZeroStillPasses: the counterpart to the above. A
+// series that exists and reads 0 — p95 of 0, an error rate of 0 for a
+// window with no errors — is real data and a real pass. The #48 fix
+// must not turn the healthiest possible reading into a blocked gate.
+func TestProdHealthGenuineZeroStillPasses(t *testing.T) {
+	calls := 0
+	g := &ProdHealthGate{
+		P95ThresholdMS:  500,
+		ErrorRateThresh: 0.01,
+		P95Query:        "p95",
+		ErrorRateQuery:  "err",
+		Query: func(_ context.Context, _ string) (float64, error) {
+			calls++
+			return 0, nil // a series is present; its value is 0
+		},
+	}
+
+	res, err := g.Check(context.Background(), "api")
+	if err != nil {
+		t.Fatalf("genuine zero blocked the gate: %v", err)
+	}
+	if res.Status != StatusPass {
+		t.Fatalf("status = %v, want pass", res.Status)
+	}
+	if calls != 2 {
+		t.Fatalf("queries run = %d, want 2", calls)
+	}
+	if res.Evidence["p95_ms"] != 0.0 || res.Evidence["error_rate"] != 0.0 {
+		t.Fatalf("evidence = %v", res.Evidence)
+	}
+}
+
+// TestProdHealthQueryErrorNamesQueryKey: a transport failure (the #42
+// timeout case included) still errors, and still says which query it
+// was, without borrowing the no-data wording.
+func TestProdHealthQueryErrorNamesQueryKey(t *testing.T) {
+	boom := errors.New("context deadline exceeded")
+	g := &ProdHealthGate{
+		P95ThresholdMS: 500,
+		P95Query:       "p95",
+		ErrorRateQuery: "err",
+		Query: func(_ context.Context, _ string) (float64, error) {
+			return 0, boom
+		},
+	}
+
+	_, err := g.Check(context.Background(), "api")
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want it to wrap %v", err, boom)
+	}
+	if !strings.Contains(err.Error(), "p95_query") {
+		t.Fatalf("error does not name the query: %v", err)
+	}
+	if strings.Contains(err.Error(), "matched no series") {
+		t.Fatalf("transport failure reported as no data: %v", err)
 	}
 }

--- a/internal/gatebuild/build_test.go
+++ b/internal/gatebuild/build_test.go
@@ -1,9 +1,15 @@
 package gatebuild
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/xdlc-labs/xdlc-agent/internal/config"
+	"github.com/xdlc-labs/xdlc-agent/internal/gate"
 	"github.com/xdlc-labs/xdlc-agent/internal/ghclient"
 )
 
@@ -114,5 +120,60 @@ func TestBranchByGitHub(t *testing.T) {
 	}
 	if got := resolve("org/never-heard-of-it"); got != "" {
 		t.Errorf("unknown repo = %q, want \"\"", got)
+	}
+}
+
+// TestProdHealthNoDataReachesTheGate: gatebuild is the only production
+// caller of promclient.Query — it wires it into ProdHealthGate.Query
+// for both the daemon and `xdlc gate check`. A query that matched no
+// series has to arrive at the gate as an error, so the gate returns no
+// verdict and the runner emits orchestrator.Blocked. Before issue #48
+// it arrived as 0, which this gate reads as a perfectly healthy
+// service.
+func TestProdHealthNoDataReachesTheGate(t *testing.T) {
+	empty := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	}))
+	t.Cleanup(empty.Close)
+
+	cfg := &config.Config{Gates: config.GatesConfig{ProdHealth: config.ProdHealthGateConfig{
+		MetricsURL:     empty.URL,
+		Thresholds:     config.Thresholds{P95MS: 500, ErrorRate: 0.01},
+		P95Query:       `p95{service="{{repo}}"}`,
+		ErrorRateQuery: "err",
+	}}}
+
+	_, err := ProdHealth(cfg).Check(context.Background(), "api")
+	if err == nil {
+		t.Fatal("empty result set produced a verdict")
+	}
+	for _, want := range []string{"p95_query", "matched no series", strconv.Quote(`p95{service="api"}`)} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error missing %q: %v", want, err)
+		}
+	}
+}
+
+// TestProdHealthGenuineZeroReachesTheGate: the counterpart. A series
+// that exists and reads 0 is still a pass through the same wiring.
+func TestProdHealthGenuineZeroReachesTheGate(t *testing.T) {
+	zero := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"value":[1,"0"]}]}}`))
+	}))
+	t.Cleanup(zero.Close)
+
+	cfg := &config.Config{Gates: config.GatesConfig{ProdHealth: config.ProdHealthGateConfig{
+		MetricsURL:     zero.URL,
+		Thresholds:     config.Thresholds{P95MS: 500, ErrorRate: 0.01},
+		P95Query:       "p95",
+		ErrorRateQuery: "err",
+	}}}
+
+	res, err := ProdHealth(cfg).Check(context.Background(), "api")
+	if err != nil {
+		t.Fatalf("genuine zero errored: %v", err)
+	}
+	if res.Status != gate.StatusPass {
+		t.Fatalf("status = %v, want pass", res.Status)
 	}
 }

--- a/internal/poller/prodhealth_nodata_test.go
+++ b/internal/poller/prodhealth_nodata_test.go
@@ -1,0 +1,268 @@
+package poller
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/xdlc-labs/xdlc-agent/internal/gate"
+	"github.com/xdlc-labs/xdlc-agent/internal/orchestrator"
+	"github.com/xdlc-labs/xdlc-agent/internal/promclient"
+)
+
+// The response bodies a Prometheus-compatible instant-query API can
+// hand back, framed exactly as the HTTP API frames them.
+//
+// noSeries is the issue #48 case: a perfectly successful query that
+// matched nothing, which is what a renamed metric, a dead exporter, a
+// relabel change or a typo in the configured query produces.
+const promNoSeries = `{"status":"success","data":{"resultType":"vector","result":[]}}`
+
+func promSeries(v string) string {
+	return `{"status":"success","data":{"resultType":"vector","result":[{"value":[1,"` + v + `"]}]}}`
+}
+
+// The four scenarios, as (p95, error-rate) response pairs against
+// thresholds of 500ms / 0.01.
+var (
+	promPairHealthy = [2]string{promSeries("120"), promSeries("0.001")}
+	promPairBreach  = [2]string{promSeries("1800"), promSeries("0.001")}
+	promPairZero    = [2]string{promSeries("0"), promSeries("0")} // series present, value 0
+	promPairEmpty   = [2]string{promNoSeries, promNoSeries}
+)
+
+// fakeProm answers the p95 query and the error-rate query separately —
+// they have different thresholds, so one shared body cannot express
+// "healthy" — and serves whichever pair is currently loaded, so one
+// test can walk a gate through healthy → breach → no-data without
+// restarting the server.
+type fakeProm struct {
+	pair atomic.Value // [2]string
+	srv  *httptest.Server
+}
+
+func newFakeProm(t *testing.T, pair [2]string) *fakeProm {
+	t.Helper()
+	f := &fakeProm{}
+	f.pair.Store(pair)
+	f.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := f.pair.Load().([2]string)
+		body := p[1]
+		if strings.Contains(r.URL.Query().Get("query"), "histogram_quantile") {
+			body = p[0]
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func (f *fakeProm) serve(pair [2]string) { f.pair.Store(pair) }
+
+const (
+	testP95Query = `histogram_quantile(0.95, http_request_duration_seconds{service="{{repo}}"})`
+	testErrQuery = `rate(http_requests_total{service="{{repo}}",code=~"5.."}[5m])`
+)
+
+// prodHealthPoller wires a real ProdHealthGate against prom through the
+// real promclient, so these tests exercise the whole path an operator's
+// daemon takes rather than a stubbed Query closure.
+func prodHealthPoller(prom *fakeProm, logs *bytes.Buffer) (*Poller, chan orchestrator.Signal) {
+	ch := make(chan orchestrator.Signal, 32)
+	g := &gate.ProdHealthGate{
+		P95ThresholdMS:  500,
+		ErrorRateThresh: 0.01,
+		P95Query:        testP95Query,
+		ErrorRateQuery:  testErrQuery,
+		Query:           promclient.New(prom.srv.URL).Query,
+	}
+	return &Poller{
+		Gate:    g,
+		Repos:   []string{"api"},
+		Source:  orchestrator.SourceProdHealth,
+		Signals: ch,
+		Log:     slog.New(slog.NewTextHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		SHA:     func(context.Context, string) (string, error) { return "deadbee", nil },
+	}, ch
+}
+
+// TestProdHealthNoDataDoesNotReadAsHealthy is the issue #48 regression,
+// end to end through promclient, ProdHealthGate and the poller.
+//
+// The gate fails only on value > threshold, so an empty result set
+// arriving as 0 always passed. Against a real daemon that meant a
+// renamed metric, a dead exporter, a relabel change or a typo in
+// p95_query silently switched breach detection off — and, worse, the
+// poller's edge trigger read that "pass" as a recovery and cleared a
+// breach that was still live, undoing the revert.
+func TestProdHealthNoDataDoesNotReadAsHealthy(t *testing.T) {
+	prom := newFakeProm(t, promPairHealthy)
+	var logs bytes.Buffer
+	p, ch := prodHealthPoller(prom, &logs)
+
+	// 1. A healthy series passes.
+	p.tick(context.Background(), 30*time.Second)
+	got := drain(ch)
+	if len(got) != 1 || got[0].Kind != orchestrator.KindPass {
+		t.Fatalf("healthy series: signals = %+v, want one pass", got)
+	}
+
+	// 2. A breaching series breaches, and that is what drives a revert.
+	prom.serve(promPairBreach)
+	p.tick(context.Background(), 30*time.Second)
+	got = drain(ch)
+	if len(got) != 1 || got[0].Kind != orchestrator.KindBreach {
+		t.Fatalf("breaching series: signals = %+v, want one breach", got)
+	}
+	if act := orchestrator.Decide(got[0]); act != orchestrator.ActionRevert {
+		t.Fatalf("breach Decide = %s, want revert", act)
+	}
+
+	// 3. The series vanishes while the breach is still live. This must
+	//    not look like the service got better.
+	prom.serve(promPairEmpty)
+	p.tick(context.Background(), 30*time.Second)
+	got = drain(ch)
+	if len(got) != 1 {
+		t.Fatalf("no data: signals = %+v, want exactly one blocked", got)
+	}
+	sig := got[0]
+	if sig.Kind == orchestrator.KindPass {
+		t.Fatal("no data reported a pass, clearing the live breach")
+	}
+	if sig.Kind != orchestrator.KindBlocked {
+		t.Fatalf("no data: kind = %s, want %s", sig.Kind, orchestrator.KindBlocked)
+	}
+	if act := orchestrator.Decide(sig); act != orchestrator.ActionNoop {
+		t.Fatalf("blocked Decide = %s, want noop", act)
+	}
+	if sig.Evidence["escalate"] != orchestrator.EscalateGateUnavailable {
+		t.Fatalf("escalate = %v, want %s", sig.Evidence["escalate"], orchestrator.EscalateGateUnavailable)
+	}
+	if sig.Evidence["gate"] != "prod-health" {
+		t.Fatalf("gate = %v", sig.Evidence["gate"])
+	}
+	reason, ok := orchestrator.BlockedReason(sig)
+	if !ok {
+		t.Fatal("BlockedReason did not recognise the signal")
+	}
+	// The reason is what reaches BACKLOG.md, the audit row and the
+	// console Activity feed, so it has to name the query that came back
+	// empty and say the verdict is unknown rather than bad.
+	// The PromQL text is quoted with %q, so it appears escaped.
+	wantQuery := strconv.Quote(strings.ReplaceAll(testP95Query, "{{repo}}", "api"))
+	for _, want := range []string{
+		"p95_query",
+		"matched no series",
+		"unknown, not healthy",
+		wantQuery,
+	} {
+		if !strings.Contains(reason, want) {
+			t.Errorf("blocked reason missing %q:\n%s", want, reason)
+		}
+	}
+	if !strings.Contains(logs.String(), "gate check failed") {
+		t.Errorf("no operator-visible log line:\n%s", logs.String())
+	}
+
+	// 4. The breach is still the last verdict on record, so when the
+	//    series comes back still breaching the poller stays quiet
+	//    (nothing changed) rather than emitting a second breach — which
+	//    is only true if step 3 did not overwrite the edge with a pass.
+	prom.serve(promPairBreach)
+	p.tick(context.Background(), 30*time.Second)
+	if got = drain(ch); len(got) != 0 {
+		t.Fatalf("blocked tick clobbered the breach edge: %+v", got)
+	}
+}
+
+// TestProdHealthNoDataNamesTheBrokenQuery: when only the error-rate
+// query has been broken, the blocked reason must say error_rate_query
+// and not send the operator looking at p95_query.
+func TestProdHealthNoDataNamesTheBrokenQuery(t *testing.T) {
+	prom := newFakeProm(t, [2]string{promSeries("120"), promNoSeries})
+	var logs bytes.Buffer
+	p, ch := prodHealthPoller(prom, &logs)
+
+	p.tick(context.Background(), 30*time.Second)
+	got := drain(ch)
+	if len(got) != 1 || got[0].Kind != orchestrator.KindBlocked {
+		t.Fatalf("signals = %+v, want one blocked", got)
+	}
+	reason, _ := orchestrator.BlockedReason(got[0])
+	if !strings.Contains(reason, "error_rate_query") {
+		t.Errorf("reason does not name error_rate_query:\n%s", reason)
+	}
+	if strings.Contains(reason, "p95_query") {
+		t.Errorf("reason blames the working query too:\n%s", reason)
+	}
+}
+
+// TestProdHealthNoDataRepeatsAreSuppressed: a permanently wrong query
+// must not write a BACKLOG.md line and an audit row every interval. The
+// issue #45 per-repo episode guard covers this, and the #48 change must
+// not route around it.
+func TestProdHealthNoDataRepeatsAreSuppressed(t *testing.T) {
+	prom := newFakeProm(t, promPairEmpty)
+	var logs bytes.Buffer
+	p, ch := prodHealthPoller(prom, &logs)
+
+	for i := 0; i < 10; i++ {
+		p.tick(context.Background(), 30*time.Second)
+	}
+	if got := drain(ch); len(got) != 1 {
+		t.Fatalf("10 no-data ticks emitted %d signals, want 1", len(got))
+	}
+	if n := strings.Count(logs.String(), "gate check failed"); n != 1 {
+		t.Fatalf("10 no-data ticks logged %d error lines, want 1:\n%s", n, logs.String())
+	}
+
+	// The series comes back healthy: a real verdict again, and the
+	// episode is re-armed so the next break is reported rather than
+	// staying silent for the life of the process.
+	prom.serve(promPairHealthy)
+	p.tick(context.Background(), 30*time.Second)
+	got := drain(ch)
+	if len(got) != 1 || got[0].Kind != orchestrator.KindPass {
+		t.Fatalf("recovery: signals = %+v, want one pass", got)
+	}
+	prom.serve(promPairEmpty)
+	p.tick(context.Background(), 30*time.Second)
+	got = drain(ch)
+	if len(got) != 1 || got[0].Kind != orchestrator.KindBlocked {
+		t.Fatalf("break after recovery: signals = %+v, want one blocked", got)
+	}
+}
+
+// TestProdHealthGenuineZeroIsAPass: p95 and error rate of 0 read off
+// series that exist is the healthiest reading there is, and the #48 fix
+// must leave it a pass. Telling this apart from an empty result set is
+// the whole point of the sentinel.
+func TestProdHealthGenuineZeroIsAPass(t *testing.T) {
+	prom := newFakeProm(t, promPairZero)
+	var logs bytes.Buffer
+	p, ch := prodHealthPoller(prom, &logs)
+
+	p.tick(context.Background(), 30*time.Second)
+	got := drain(ch)
+	if len(got) != 1 {
+		t.Fatalf("signals = %+v, want one", got)
+	}
+	if got[0].Kind != orchestrator.KindPass {
+		t.Fatalf("kind = %s, want pass — a present series reading 0 is data", got[0].Kind)
+	}
+	if got[0].Evidence["p95_ms"] != 0.0 || got[0].Evidence["error_rate"] != 0.0 {
+		t.Fatalf("evidence = %v", got[0].Evidence)
+	}
+	if strings.Contains(logs.String(), "gate check failed") {
+		t.Fatalf("genuine zero logged a gate failure:\n%s", logs.String())
+	}
+}

--- a/internal/promclient/query.go
+++ b/internal/promclient/query.go
@@ -8,6 +8,7 @@ package promclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -35,6 +36,30 @@ const DefaultTimeout = 10 * time.Second
 // without an HTTP client. Shared, like http.DefaultClient, but with a
 // Timeout — the whole point of not using http.DefaultClient.
 var defaultHTTP = &http.Client{Timeout: DefaultTimeout}
+
+// ErrNoData reports that a query ran successfully and matched no series
+// at all. Query wraps it (with the PromQL text) instead of returning a
+// bare 0, because the two are not the same fact and the difference is
+// safety-critical for any caller that compares the value to a
+// threshold: "no series" carries no information about the service,
+// while 0 does.
+//
+// Before issue #48 an empty result set came back as 0, nil. On the
+// prod-health gate — whose only failure condition is value > threshold,
+// and whose action is Revert — that read as p95=0 / error_rate=0, i.e.
+// perfectly healthy, at the exact moment the gate's inputs had broken
+// (metric renamed, exporter down, relabelled away, a typo in the
+// query). The gate silently lost the ability to detect a breach, and
+// the poller's edge trigger cleared any breach already live.
+//
+// A caller that genuinely wants zero for an absent series can still
+// have it, but must now say so:
+//
+//	v, err := c.Query(ctx, q)
+//	if errors.Is(err, promclient.ErrNoData) {
+//		v, err = 0, nil
+//	}
+var ErrNoData = errors.New("query matched no series")
 
 // Client queries one PromQL instant-query HTTP API.
 type Client struct {
@@ -70,8 +95,11 @@ type queryResponse struct {
 }
 
 // Query runs promQL as an instant query and returns the first result's
-// scalar value. Returns 0 if the query has no result series (e.g. an
-// error-rate query with zero requests in the window).
+// scalar value.
+//
+// A query that matched no series returns ErrNoData, wrapped with the
+// PromQL text, rather than 0 — see ErrNoData for why. A series that
+// exists and holds 0 returns 0, nil, as it always has.
 func (c *Client) Query(ctx context.Context, promQL string) (float64, error) {
 	u := fmt.Sprintf("%s/api/v1/query?%s", c.BaseURL, url.Values{"query": {promQL}}.Encode())
 
@@ -98,7 +126,7 @@ func (c *Client) Query(ctx context.Context, promQL string) (float64, error) {
 		return 0, fmt.Errorf("promclient: query %q: status %q", promQL, qr.Status)
 	}
 	if len(qr.Data.Result) == 0 {
-		return 0, nil
+		return 0, fmt.Errorf("promclient: %w: %q", ErrNoData, promQL)
 	}
 
 	valStr, ok := qr.Data.Result[0].Value[1].(string)

--- a/internal/promclient/query_test.go
+++ b/internal/promclient/query_test.go
@@ -2,8 +2,10 @@ package promclient
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -30,15 +32,44 @@ func TestQuery(t *testing.T) {
 	}
 }
 
+// TestQueryEmptyResult: a query that matched no series must report
+// ErrNoData, not 0. Returning 0 made the prod-health gate — whose only
+// failure condition is value > threshold — read a renamed metric, a
+// dead exporter or a typo'd query as a perfectly healthy service, and
+// silently stop detecting breaches (issue #48).
 func TestQueryEmptyResult(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
 	}))
 	t.Cleanup(srv.Close)
 
-	v, err := New(srv.URL).Query(context.Background(), "none")
+	v, err := New(srv.URL).Query(context.Background(), "absent_metric")
+	if !errors.Is(err, ErrNoData) {
+		t.Fatalf("err = %v, want ErrNoData", err)
+	}
+	if v != 0 {
+		t.Fatalf("v = %v, want the zero value alongside the error", v)
+	}
+	// The text lands in a BACKLOG.md line and an audit row, so it has to
+	// name the query that came back empty.
+	if !strings.Contains(err.Error(), "absent_metric") {
+		t.Fatalf("error does not name the query: %v", err)
+	}
+}
+
+// TestQueryGenuineZero: a series that exists and holds 0 is data, not
+// missing data. An error-rate query with zero errors in the window is
+// the everyday case, and it must stay a plain 0, nil — otherwise the
+// #48 fix would block the gate on every healthy service.
+func TestQueryGenuineZero(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"value":[1,"0"]}]}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	v, err := New(srv.URL).Query(context.Background(), "err_rate")
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("genuine zero returned an error: %v", err)
 	}
 	if v != 0 {
 		t.Fatalf("v = %v, want 0", v)


### PR DESCRIPTION
Fixes #48, which I split out of #42 during the prod-health verification and deliberately left unfixed because it needed a design decision rather than a mechanical change.

**The bug.** `promclient.Query` returned `0, nil` for a query that matched no series — deliberate and documented. The problem is what that meant on the prod-health gate, which fails only when a value *exceeds* its threshold, so a query returning zero always passed. If a series stopped existing (metric renamed, exporter down, a relabel change, a typo in `p95_query` or `error_rate_query`) the gate read p95=0 and error_rate=0, reported healthy at the exact moment its inputs had broken, and the poller's edge trigger **cleared any breach already live**. This gate's action is Revert, so that is the dangerous direction to fail in, and it was indistinguishable from a genuinely healthy service.

Distinct from the timeout fixed in #42: a *hung* Prometheus now errors loudly. One that answers promptly with nothing still read as good.

**The fix.** An empty result set is now `promclient.ErrNoData`. The gate treats it as no verdict, which the runners already turn into a `blocked` signal recorded with `escalate=gate_unavailable` and mapped to a noop — the vocabulary #45 added for exactly this case. No data is unknown, not good, and not a fail either.

A sentinel rather than a `(value, found, error)` signature: `promclient` has exactly one production caller, the `Query` field on `ProdHealthGate` wired in `gatebuild`. I checked before choosing — `internal/demo` supplies its own closure and never touches `promclient`, and `xdlc gate check` reaches it only through `gatebuild`. A signature change would have churned three sites for one caller, and a caller that genuinely wants zero for an absent series can still opt in explicitly.

The error names the **config key**, not just the PromQL, so an operator reading a `BACKLOG.md` line or an audit row knows which of the two queries to look at:

```
prod-health gate: p95_query matched no series, so prod health is unknown, not healthy:
check the metric name, its exporter, and any relabelling before trusting this gate again:
promclient: query matched no series: "histogram_quantile(0.95, ...)"
```

A transport failure keeps the plain wording, so the #42 timeout case is not mislabelled as no-data.

**Guarded against over-correction**, in both directions and at every layer, because the obvious way to get this wrong is to start blocking on a legitimate zero:

| case | verdict |
|---|---|
| healthy series | pass |
| breaching series | breach → Revert |
| **genuine zero, series really exists** | **still a pass**, not blocked |
| empty result set | `blocked`, `escalate=gate_unavailable`, no Revert |

Verified end to end against a real daemon and a switchable fake Prometheus, plus two things I specifically wanted confirmed: a blocked tick does **not** clear a live breach (the breach remained the recorded edge), and the per-repo repeat suppression still holds — eleven consecutive empty ticks produced exactly one signal, one error line and one `BACKLOG.md` row.

**Old-behaviour contrast**, built from `origin/main`: the series vanished mid-breach and it emitted `kind=pass action=noop` with `p95_ms=0 error_rate=0`, writing a row that cleared the breach, and zero blocked signals. On `main` the empty case is byte-identical to the genuine-zero case. `xdlc gate check prod-health` shows the same: `pass` and exit 0 there, the error above and exit 1 here.

**Checklist**
- [x] `make build && make test && make lint` clean (`go test -race`, all 25 packages; `golangci-lint` 0 issues)
- [x] `test -z "$(gofmt -l cmd internal services)"`
- [x] New/changed behavior documented (`CHANGELOG.md`, code comments); no config key added, so no schema change
- [x] UI not touched, so the go:embed console is left alone
- [x] Vendor-specific logic stays behind the existing interfaces: the sentinel lives in `internal/promclient`
