### PR TITLE
Feed the last few Fix recordings into the next Fix prompt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **The last few Fix recordings now reach the next Fix prompt.** `LESSONS.md` keeps one 200-character line per outcome; the sessions on disk hold the prompt, the output and the patch, and the agent never saw any of it — so a second Fix on a repo re-derived what the first one had already worked out, and could repeat an approach that was measured to fail. The Fix prompt gains a `---BEGIN PRIOR FIX RECORD---` block after the lessons: for the last `agent.sessions.prior_fixes` finished sessions on this repo with the same `source`, each entry carries the session id and age, the run's status, the agent's own verdict and summary, and the first 40 lines of `diff.patch` — or an explicit "changed nothing" for a run that delivered no patch, which is the entry most likely to stop a repeat. Same `source` only, because a red CI run and a prod-metrics breach have close to nothing to teach each other and mixing them spends the budget on the less relevant history. The block is trusted content (it is xdlc's own recording of its own runs, not gate output) but is framed as records rather than instructions, and capped at 8 KB — a quarter of the evidence budget, so history can never crowd out the failure that is red now. Default 2 entries; `agent.sessions.prior_fixes: 0` sends none, and recording being off implies none. `xdlc fix` gets the same block from its own recordings under the user cache dir
+
 ### Changed
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,21 +37,7 @@ The pieces the open items below build on:
 
 Ordered by value ÷ effort.
 
-### 1. Feed past sessions into the next Fix prompt (S, high)
-
-**Today:** `LESSONS.md` keeps one 200-character line per outcome, now carrying the agent's own
-verdict summary rather than just the symptom. The sessions on disk are far richer than that
-line and the agent never sees them, so a second Fix on the same repo re-derives what the first
-one already worked out.
-
-**Change:** `FixPrompt` gains a `priorSessions` block after `lessons`: for the last 2–3
-sessions on this repo with the same `source`, the first ~40 lines of `diff.patch` plus the
-run's status. Cap the block at 8 KB, place it in a trusted block. Optionally a `summary.md`
-written by a cheap second pass (`agent.sessions.summarize`, default off).
-
-**Measure before keeping:** Fix success rate on the demo repo, before and after.
-
-### 2. Live Fix states and a stall watchdog (S, high)
+### 1. Live Fix states and a stall watchdog (S, high)
 
 **Today:** `FixQueueStats()` returns two integers and the console shows `fix_queue_depth`. A
 Fix that is running is indistinguishable from one that is wedged.
@@ -68,7 +54,7 @@ Fix that is running is indistinguishable from one that is wedged.
   format (`claude -p --output-format json` prints nothing until it exits), so it stays opt-in
   and ships together with a switch to `stream-json`, not before.
 
-### 3. Console view of a session (S, medium)
+### 2. Console view of a session (S, medium)
 
 The recordings exist but are reachable only from the CLI. Add operator-token endpoints
 (`GET /api/sessions`, `/{id}`, `/{id}/diff`, `/{id}/prompt`) and let a `/repos/$id` timeline
@@ -78,7 +64,7 @@ output.
 Serving unscrubbed prompts over HTTP is a real exposure step, unlike writing them to a 0600
 file: gate it on the operator role and document that in [SECURITY.md](SECURITY.md).
 
-### 4. Context on demand: `xdlc mcp` (L, high)
+### 3. Context on demand: `xdlc mcp` (L, high)
 
 **Today:** the dispatcher inlines failed-job logs and metrics, trimmed to 32 KB. On a large CI
 matrix the one useful line is often the one that got cut, and the agent has no way to ask for
@@ -94,19 +80,18 @@ agent pulls detail when it needs it. Behind `agent.mcp.enabled`, default off unt
 Every tool call is appended to the session recording, so "what did it look at" stays
 answerable after the fact.
 
-### 5. Grid view of live Fixes (M, low)
+### 4. Grid view of live Fixes (M, low)
 
 A read-only `/fixes` route: one card per in-flight Fix with its output tail streamed over SSE,
-for watching a fleet-wide burst of Fixes at once. Needs item 2 first.
+for watching a fleet-wide burst of Fixes at once. Needs item 1 first.
 
 ## Sequencing
 
-1. Item 1 first — it is small and reuses what already lands on disk. Worktrees have shipped,
-   so a prior session's diff now describes an isolated run rather than a shared clone.
-2. Item 2 only alongside the switch to a streaming provider output format.
-3. Item 4 after item 1, since `prior_sessions` is one of its tools.
-4. Item 5 needs item 2 first.
-5. Each of these touches the hosted guides — [architecture](https://xdlc.dev/agent/docs/architecture),
+1. Item 1 only alongside the switch to a streaming provider output format.
+2. Item 3 next: prior sessions now reach the prompt as a fixed block, and `prior_sessions`
+   as an MCP tool is the version of that the agent can ask for more of.
+3. Item 4 needs item 1 first.
+4. Each of these touches the hosted guides — [architecture](https://xdlc.dev/agent/docs/architecture),
    [Fix modes](https://xdlc.dev/agent/docs/fix-modes),
    [Fix sessions](https://xdlc.dev/agent/docs/sessions), configuration and the API reference —
    plus [CHANGELOG.md](CHANGELOG.md).

--- a/cmd/xdlc-agent/main.go
+++ b/cmd/xdlc-agent/main.go
@@ -161,6 +161,7 @@ func daemonCmd() *cobra.Command {
 				log.Info("session recording", "dir", sessions.Root, "retain", sessions.Retain)
 			}
 			disp.Sessions = sessions
+			disp.PriorFixes = cfg.Agent.PriorFixes()
 			disp.DefaultProvider = cfg.Agent.Provider
 			disp.Route = cfg.Agent.Route
 			disp.Providers = append([]string(nil), cfg.Agent.Providers...)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -74,6 +74,8 @@ agent:
   #   dir: sessions
   #   retain: 720h
   #   max_file_bytes: 2097152
+  #   prior_fixes: 2                # earlier Fixes (same repo + source) summarized
+  #                                 # into the next Fix prompt; 0 sends none
 
 # fleet:
 #   flap_max_cycles: 3

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -393,12 +393,43 @@ type SessionsConfig struct {
 	Retain time.Duration `yaml:"retain"`
 	// MaxFileBytes caps one artifact (prompt, output, diff). 0 → 2 MiB.
 	MaxFileBytes int64 `yaml:"max_file_bytes"`
+	// PriorFixes is how many earlier finished Fixes for the same repo
+	// and source are summarized into the next Fix prompt — what each one
+	// changed and whether it worked. Nil → DefaultPriorFixes; 0 turns
+	// the block off. Pointer so `prior_fixes: 0` is distinguishable
+	// from an operator who never mentioned it.
+	//
+	// The recordings are already on disk; without this the agent never
+	// sees them, so a second Fix on one repo re-derives what the first
+	// one worked out. Each entry costs input tokens, and the prompt caps
+	// the whole block at 8 KB, so more than a handful buys nothing.
+	PriorFixes *int `yaml:"prior_fixes"`
 }
+
+// DefaultPriorFixes is how many earlier sessions reach the Fix prompt
+// when agent.sessions.prior_fixes is unset.
+const DefaultPriorFixes = 2
 
 // SessionsEnabled reports whether Fix session recording is on
 // (default true).
 func (a AgentConfig) SessionsEnabled() bool {
 	return a.Sessions.Enabled == nil || *a.Sessions.Enabled
+}
+
+// PriorFixes returns how many earlier sessions to summarize into a Fix
+// prompt: 0 when recording is off (there would be nothing to read),
+// DefaultPriorFixes when unset, and never negative.
+func (a AgentConfig) PriorFixes() int {
+	if !a.SessionsEnabled() {
+		return 0
+	}
+	if a.Sessions.PriorFixes == nil {
+		return DefaultPriorFixes
+	}
+	if n := *a.Sessions.PriorFixes; n > 0 {
+		return n
+	}
+	return 0
 }
 
 // SessionsDir returns the configured session root, defaulting to

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -59,6 +59,10 @@ type Dispatcher struct {
 	// Sessions records each Fix's prompt, output and diff to disk.
 	// nil (or a nil *session.Store) disables recording.
 	Sessions *session.Store
+	// PriorFixes is how many earlier finished sessions for this repo and
+	// source are summarized into the Fix prompt. 0 disables the block;
+	// it needs Sessions, since the recordings on disk are what it reads.
+	PriorFixes int
 	// Lessons optional past-Fix inject (issue #19). nil skips.
 	Lessons interface {
 		Record(repo, source, outcome, symptom string) error
@@ -387,6 +391,7 @@ func (d *Dispatcher) fixInner(ctx context.Context, s orchestrator.Signal) (res o
 	if d.Lessons != nil {
 		lessons = d.Lessons.ForRepo(s.Repo, 5)
 	}
+	priorSessions := d.priorSessionsBlock(s, sess.ID())
 
 	// The diagnose pass runs once, ahead of the ladder: its subject is
 	// the failure, not any one patch attempt, so re-planning per attempt
@@ -432,16 +437,17 @@ func (d *Dispatcher) fixInner(ctx context.Context, s orchestrator.Signal) (res o
 
 	for attempt = 1; ; attempt++ {
 		prompt := subagent.BuildFixPrompt(subagent.FixRequest{
-			Repo:      s.Repo,
-			Reason:    reason,
-			Evidence:  evidence,
-			Mode:      d.FixMode,
-			PRBranch:  prBranch,
-			TeamRules: teamRules,
-			Lessons:   lessons,
-			Plan:      plan,
-			Retry:     retry,
-			NoPush:    wt != nil,
+			Repo:          s.Repo,
+			Reason:        reason,
+			Evidence:      evidence,
+			Mode:          d.FixMode,
+			PRBranch:      prBranch,
+			TeamRules:     teamRules,
+			Lessons:       lessons,
+			PriorSessions: priorSessions,
+			Plan:          plan,
+			Retry:         retry,
+			NoPush:        wt != nil,
 		})
 		if werr := sess.Write(session.AttemptFile(session.FilePrompt, attempt), prompt); werr != nil {
 			d.Log.Warn("session prompt write failed", "repo", s.Repo, "error", werr)
@@ -843,6 +849,72 @@ func (d *Dispatcher) pushWorktree(ctx context.Context, s orchestrator.Signal, wt
 	}
 	d.Log.Info("pushed fix", "repo", s.Repo, "from", wt.Branch, "to", target)
 	return true, nil
+}
+
+// priorSessionsBlock renders the last d.PriorFixes finished Fixes for
+// this repo and source into the text BuildFixPrompt frames. Empty when
+// the feature is off, recording is off, or this is the repo's first Fix.
+//
+// Same source only: a Fix for a red CI run and a Fix for a prod-metrics
+// breach have almost nothing to teach each other, and mixing them
+// spends the block's budget on the less relevant history.
+//
+// excludeID is this run's own session, which is already open and has an
+// empty diff — including it would tell the agent its own Fix delivered
+// nothing before it had started.
+func (d *Dispatcher) priorSessionsBlock(s orchestrator.Signal, excludeID string) string {
+	if d.PriorFixes <= 0 || d.Sessions == nil {
+		return ""
+	}
+	prior := d.Sessions.Recent(s.Repo, string(s.Source), excludeID, d.PriorFixes, 0)
+	if len(prior) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i, p := range prior {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		fmt.Fprintf(&b, "Fix %s (%s ago", p.ID, prettyAge(time.Since(p.StartedAt)))
+		if p.Status != "" {
+			fmt.Fprintf(&b, ", run %s", p.Status)
+		}
+		b.WriteString(")\n")
+		if p.Outcome != "" {
+			fmt.Fprintf(&b, "  agent verdict: %s\n", p.Outcome)
+		}
+		if sum := strings.TrimSpace(p.Summary); sum != "" {
+			fmt.Fprintf(&b, "  agent said: %s\n", sum)
+		}
+		if p.Diff == "" {
+			b.WriteString("  changed nothing (no patch recorded)\n")
+			continue
+		}
+		head := "  patch"
+		if p.DiffTruncated {
+			head = fmt.Sprintf("  patch (first %d lines of %d files)",
+				session.DefaultPriorDiffLines, p.Changed)
+		}
+		fmt.Fprintf(&b, "%s:\n%s\n", head, p.Diff)
+	}
+	d.Log.Debug("prior sessions in fix prompt", "repo", s.Repo, "count", len(prior))
+	return b.String()
+}
+
+// prettyAge renders a duration the way an operator reads one, because
+// a raw time.Duration in a prompt ("2h13m41.9s") spends tokens on
+// precision the agent cannot use.
+func prettyAge(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "under a minute"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 48*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
 }
 
 func (d *Dispatcher) recordLesson(s orchestrator.Signal, outcome, symptom string) {

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -1709,3 +1709,144 @@ func TestWorktreeDisabledUsesSharedClone(t *testing.T) {
 		t.Fatal("worktree root created while worktrees are disabled")
 	}
 }
+
+// priorSessionsBlock is what turns recordings on disk into prompt text.
+// Its job is to describe what an earlier Fix did without pretending it
+// was a success: status, the agent's own verdict, and the head of the
+// patch.
+func TestPriorSessionsBlockRendersEarlierFixes(t *testing.T) {
+	st, err := session.Open(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prev, err := st.Start(session.Meta{Repo: "svc", Source: "ci"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := prev.Write(session.FileDiff, "--- a/go.mod\n+++ b/go.mod\n+require foo v1.2.3\n"); err != nil {
+		t.Fatal(err)
+	}
+	prev.SetVerdict("gave_up", "bumped the pin, still red", 1)
+	prev.SetResult("error", "reverify failed", nil)
+	if err := prev.Finish(); err != nil {
+		t.Fatal(err)
+	}
+
+	d := &Dispatcher{Sessions: st, PriorFixes: 3, Log: slog.New(slog.DiscardHandler)}
+	sig := orchestrator.Signal{Repo: "svc", Source: orchestrator.SourceCI}
+	got := d.priorSessionsBlock(sig, "some-other-session")
+
+	for _, want := range []string{prev.ID(), "run error", "gave_up", "bumped the pin, still red", "+require foo v1.2.3"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("block missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestPriorSessionsBlockOffByConfigAndWithoutStore(t *testing.T) {
+	st, err := session.Open(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prev, err := st.Start(session.Meta{Repo: "svc", Source: "ci"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prev.SetResult("ok", "", nil)
+	if err := prev.Finish(); err != nil {
+		t.Fatal(err)
+	}
+	sig := orchestrator.Signal{Repo: "svc", Source: orchestrator.SourceCI}
+	log := slog.New(slog.DiscardHandler)
+
+	if got := (&Dispatcher{Sessions: st, PriorFixes: 0, Log: log}).priorSessionsBlock(sig, ""); got != "" {
+		t.Fatalf("prior_fixes 0 must send nothing, got:\n%s", got)
+	}
+	if got := (&Dispatcher{PriorFixes: 3, Log: log}).priorSessionsBlock(sig, ""); got != "" {
+		t.Fatalf("no recordings means no history to read, got:\n%s", got)
+	}
+}
+
+// A run that delivered nothing is the most useful thing to pass on, so
+// it must not read as a silent success.
+func TestPriorSessionsBlockNamesEmptyPatch(t *testing.T) {
+	st, err := session.Open(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prev, err := st.Start(session.Meta{Repo: "svc", Source: "ci"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prev.SetResult("error", "subagent timeout", nil)
+	if err := prev.Finish(); err != nil {
+		t.Fatal(err)
+	}
+	d := &Dispatcher{Sessions: st, PriorFixes: 2, Log: slog.New(slog.DiscardHandler)}
+	got := d.priorSessionsBlock(orchestrator.Signal{Repo: "svc", Source: orchestrator.SourceCI}, "")
+	if !strings.Contains(got, "changed nothing") {
+		t.Fatalf("want an explicit no-patch line:\n%s", got)
+	}
+}
+
+// The point of the feature: the second Fix on a repo is told what the
+// first one did, instead of re-deriving it from the same evidence.
+func TestFixFeedsPriorSessionIntoNextPrompt(t *testing.T) {
+	_, workDir := setupOrigin(t)
+	mgr := testManager(t, workDir)
+	st, err := session.Open(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &fakeRunner{}
+	d := New(mgr, runner, silentLogger())
+	d.Sessions = st
+	d.PriorFixes = 2
+
+	sig := orchestrator.Signal{
+		Repo:     "svc",
+		Source:   orchestrator.SourceCI,
+		Kind:     orchestrator.KindFail,
+		Evidence: map[string]any{"run_url": "http://ci/123"},
+	}
+	if _, err := d.Fix(context.Background(), sig); err != nil {
+		t.Fatalf("first Fix: %v", err)
+	}
+	first := strings.TrimSpace(runner.gotPrompt)
+	if strings.Contains(first, "earlier Fix runs") {
+		t.Fatalf("the repo's first Fix has no history to be given:\n%s", first)
+	}
+
+	sig.Evidence = map[string]any{"run_url": "http://ci/124"}
+	if _, err := d.Fix(context.Background(), sig); err != nil {
+		t.Fatalf("second Fix: %v", err)
+	}
+	second := runner.gotPrompt
+	if !strings.Contains(second, "earlier Fix runs") {
+		t.Fatalf("second Fix got no prior-session block:\n%s", second)
+	}
+	sessions, err := st.List("svc", 0)
+	if err != nil || len(sessions) != 2 {
+		t.Fatalf("want two recordings, got %d (%v)", len(sessions), err)
+	}
+	// Read the prior-record block on its own. The running session's id
+	// also reaches the prompt through evidence["session_id"], so a
+	// whole-prompt search cannot tell "given as history" from "named as
+	// this run".
+	start := strings.Index(second, "---BEGIN PRIOR FIX RECORD---")
+	end := strings.Index(second, "---END PRIOR FIX RECORD---")
+	if start < 0 || end < start {
+		t.Fatalf("prior record block missing or malformed:\n%s", second)
+	}
+	block := second[start:end]
+	// List is newest first: [0] is the run that built this prompt.
+	if !strings.Contains(block, sessions[1].ID) {
+		t.Fatalf("prior session %s not named in the block:\n%s", sessions[1].ID, block)
+	}
+	if strings.Contains(block, sessions[0].ID) {
+		t.Fatal("a Fix must not be handed its own still-open session as history")
+	}
+	if !strings.Contains(block, "app.txt") {
+		t.Fatalf("the earlier patch did not reach the prompt:\n%s", block)
+	}
+}

--- a/internal/oneshot/oneshot.go
+++ b/internal/oneshot/oneshot.go
@@ -200,6 +200,9 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 		return res, fmt.Errorf("oneshot: sessions: %w", err)
 	}
 	disp.Sessions = sessions
+	// The one-shot path keeps its recordings in the user cache dir, so a
+	// second `xdlc fix` on the same repo can read what the first tried.
+	disp.PriorFixes = config.DefaultPriorFixes
 	res.SessionDir = sessionDir
 
 	sig := orchestrator.Signal{

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -440,3 +440,87 @@ func Diff(ctx context.Context, repoDir, baseSHA string) (patch string, changed i
 	}
 	return patch, changed
 }
+
+// DefaultPriorDiffLines is how much of an earlier Fix's patch travels
+// in the next prompt. Enough to show which files it touched and the
+// shape of the change; not enough to reproduce it line by line, which
+// is not the point — the next run has the repo itself for that.
+const DefaultPriorDiffLines = 40
+
+// PriorFix is a compact record of an earlier Fix on the same repo, for
+// the next Fix's prompt. The recording on disk is far richer than this;
+// what a following run needs is only what was tried and whether it
+// worked, so a whole session is reduced to its head.
+type PriorFix struct {
+	ID        string
+	StartedAt time.Time
+	// Status is the daemon's own verdict — "ok" or "error".
+	Status string
+	// Outcome and Summary are the agent's self-report ("fixed",
+	// "bumped the pinned version"), empty when it emitted no verdict.
+	Outcome string
+	Summary string
+	// Changed is how many files the patch touched.
+	Changed int
+	// Diff is the first diffLines lines of diff.patch, "" when the run
+	// delivered nothing — which is itself worth telling the next run.
+	Diff string
+	// DiffTruncated reports that Diff is only the head of the patch.
+	DiffTruncated bool
+}
+
+// Recent returns up to limit finished sessions for repo with the same
+// source, newest first, excluding excludeID (the caller's own,
+// still-running session). diffLines <= 0 uses DefaultPriorDiffLines.
+//
+// Unfinished sessions are skipped: a Fix running right now in another
+// worktree has an empty diff and no status, so it can only mislead.
+// Errors are swallowed — a Fix must not fail because an old recording
+// was hand-deleted mid-read.
+func (s *Store) Recent(repo, source, excludeID string, limit, diffLines int) []PriorFix {
+	if s == nil || limit <= 0 {
+		return nil
+	}
+	if diffLines <= 0 {
+		diffLines = DefaultPriorDiffLines
+	}
+	metas, err := s.List(repo, 0)
+	if err != nil {
+		return nil
+	}
+	out := make([]PriorFix, 0, limit)
+	for _, m := range metas {
+		if m.ID == excludeID || m.EndedAt.IsZero() {
+			continue
+		}
+		if source != "" && m.Source != source {
+			continue
+		}
+		p := PriorFix{
+			ID: m.ID, StartedAt: m.StartedAt, Status: m.Status,
+			Outcome: m.Outcome, Summary: m.Summary, Changed: m.Changed,
+		}
+		if patch, err := s.ReadFile(m.ID, FileDiff); err == nil {
+			p.Diff, p.DiffTruncated = headLines(patch, diffLines)
+		}
+		out = append(out, p)
+		if len(out) == limit {
+			break
+		}
+	}
+	return out
+}
+
+// headLines returns the first n lines of text and whether anything was
+// dropped.
+func headLines(text string, n int) (string, bool) {
+	text = strings.TrimRight(text, "\n")
+	if text == "" {
+		return "", false
+	}
+	lines := strings.Split(text, "\n")
+	if len(lines) <= n {
+		return text, false
+	}
+	return strings.Join(lines[:n], "\n"), true
+}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -224,3 +224,123 @@ func TestNewIDIsFilesystemSafe(t *testing.T) {
 		t.Fatalf("want sortable timestamp prefix, got %q", id)
 	}
 }
+
+// writeSession records one finished session, the way a Fix would.
+func writeSession(t *testing.T, st *Store, repo, source, status, outcome, summary, diff string) string {
+	t.Helper()
+	sess, err := st.Start(Meta{Repo: repo, Source: source, Kind: "fail", Provider: "claude"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sess.Write(FileDiff, diff); err != nil {
+		t.Fatal(err)
+	}
+	sess.SetVerdict(outcome, summary, 1)
+	sess.SetResult(status, "", nil)
+	if err := sess.Finish(); err != nil {
+		t.Fatal(err)
+	}
+	return sess.ID()
+}
+
+func TestRecentReturnsFinishedSessionsForRepoAndSource(t *testing.T) {
+	st, err := Open(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := writeSession(t, st, "svc", "ci", "error", "gave_up", "not fixable here", "--- a/one\n+++ b/one\n")
+	recent := writeSession(t, st, "svc", "ci", "ok", "fixed", "bumped the pin", "--- a/two\n+++ b/two\n")
+	writeSession(t, st, "svc", "prod", "ok", "fixed", "other source", "--- a/three\n")
+	writeSession(t, st, "other", "ci", "ok", "fixed", "other repo", "--- a/four\n")
+
+	got := st.Recent("svc", "ci", "", 5, 0)
+	if len(got) != 2 {
+		t.Fatalf("want the two ci sessions for svc, got %d: %+v", len(got), got)
+	}
+	// Newest first: the ladder cares most about what just happened.
+	if got[0].ID != recent || got[1].ID != old {
+		t.Fatalf("want %s then %s, got %s then %s", recent, old, got[0].ID, got[1].ID)
+	}
+	if got[0].Status != "ok" || got[0].Outcome != "fixed" || got[0].Summary != "bumped the pin" {
+		t.Fatalf("verdict fields not carried: %+v", got[0])
+	}
+	if !strings.Contains(got[0].Diff, "b/two") {
+		t.Fatalf("want the patch, got %q", got[0].Diff)
+	}
+	if got[0].DiffTruncated {
+		t.Fatal("a two-line patch was reported as truncated")
+	}
+}
+
+func TestRecentSkipsOwnAndUnfinishedSessions(t *testing.T) {
+	st, err := Open(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := writeSession(t, st, "svc", "ci", "ok", "fixed", "landed", "--- a/one\n")
+	// A Fix running right now in another worktree: no status, no diff,
+	// nothing a following run can learn from.
+	if _, err := st.Start(Meta{Repo: "svc", Source: "ci"}); err != nil {
+		t.Fatal(err)
+	}
+	mine, err := st.Start(Meta{Repo: "svc", Source: "ci"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := st.Recent("svc", "ci", mine.ID(), 5, 0)
+	if len(got) != 1 || got[0].ID != done {
+		t.Fatalf("want only %s, got %+v", done, got)
+	}
+}
+
+func TestRecentHonorsLimitAndDiffLines(t *testing.T) {
+	st, err := Open(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 4; i++ {
+		writeSession(t, st, "svc", "ci", "ok", "fixed", "n", strings.Repeat("+line\n", 100))
+	}
+	got := st.Recent("svc", "ci", "", 2, 3)
+	if len(got) != 2 {
+		t.Fatalf("limit ignored: %d entries", len(got))
+	}
+	if lines := strings.Count(got[0].Diff, "\n") + 1; lines != 3 {
+		t.Fatalf("want 3 diff lines, got %d", lines)
+	}
+	if !got[0].DiffTruncated {
+		t.Fatal("a clipped patch must say so, or the agent reads a partial hunk as the whole change")
+	}
+}
+
+func TestRecentDisabledAndEmpty(t *testing.T) {
+	var nilStore *Store
+	if got := nilStore.Recent("svc", "ci", "", 3, 0); got != nil {
+		t.Fatalf("nil store must yield nothing, got %+v", got)
+	}
+	st, err := Open(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := st.Recent("svc", "ci", "", 0, 0); got != nil {
+		t.Fatalf("limit 0 must yield nothing, got %+v", got)
+	}
+	if got := st.Recent("svc", "ci", "", 3, 0); len(got) != 0 {
+		t.Fatalf("first Fix on a repo must yield nothing, got %+v", got)
+	}
+}
+
+// A run that delivered no patch is still worth reporting: "the last
+// attempt changed nothing" is exactly what stops a repeat.
+func TestRecentKeepsSessionsWithNoDiff(t *testing.T) {
+	st, err := Open(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := writeSession(t, st, "svc", "ci", "error", "needs_human", "needs a decision", "")
+	got := st.Recent("svc", "ci", "", 3, 0)
+	if len(got) != 1 || got[0].ID != id || got[0].Diff != "" {
+		t.Fatalf("want the empty-diff session, got %+v", got)
+	}
+}

--- a/internal/subagent/prompt.go
+++ b/internal/subagent/prompt.go
@@ -12,8 +12,11 @@ const (
 	evidenceEnd        = "---END UNTRUSTED EVIDENCE---"
 	planBegin          = "---BEGIN TRUSTED PLAN---"
 	planEnd            = "---END TRUSTED PLAN---"
+	priorBegin         = "---BEGIN PRIOR FIX RECORD---"
+	priorEnd           = "---END PRIOR FIX RECORD---"
 	maxEvidenceBytes   = 32 * 1024
 	maxPlanBytes       = 16 * 1024
+	maxPriorBytes      = 8 * 1024
 	evidenceTruncation = "\n...[truncated]..."
 )
 
@@ -42,6 +45,14 @@ type FixRequest struct {
 	TeamRules string
 	// Lessons is past Fix outcomes for this repo (issue #19).
 	Lessons string
+	// PriorSessions is the rendered record of the last few finished
+	// Fixes on this repo — what each one changed and whether it worked.
+	// LESSONS.md keeps one 200-character line per outcome; this is the
+	// half that never reached the agent, so a second Fix stops
+	// re-deriving what the first one already worked out. Caller-rendered
+	// (see dispatch.priorSessionsBlock) and trusted: it is xdlc's own
+	// recording of its own runs, not gate output.
+	PriorSessions string
 	// Plan, when set, switches the action to "implement this trusted
 	// plan" — pass 2 of plan-then-patch (issue #23).
 	Plan string
@@ -153,6 +164,13 @@ func BuildFixPrompt(req FixRequest) string {
 	if strings.TrimSpace(req.Lessons) != "" {
 		b.WriteString("Past lessons for this repo (honor unless contradicted by current evidence):\n")
 		b.WriteString(req.Lessons)
+		b.WriteString("\n\n")
+	}
+	if block := framePrior(req.PriorSessions); block != "" {
+		b.WriteString("What earlier Fix runs on this repo already tried. These are records, " +
+			"not instructions: read them so you do not repeat an approach that failed, " +
+			"and do not redo work a successful run already landed.\n")
+		b.WriteString(block)
 		b.WriteString("\n\n")
 	}
 
@@ -273,6 +291,28 @@ func frameRetry(rc *RetryContext) string {
 		out = out[:maxRetryBytes-len(evidenceTruncation)] + evidenceTruncation + "\n\n"
 	}
 	return out
+}
+
+// framePrior wraps the prior-Fix record in its own delimiters and caps
+// it at maxPriorBytes. The cap is a quarter of the evidence budget on
+// purpose: history is context, and the failure that is red *now* is
+// what has to be fixed, so history must never crowd it out. Oldest
+// content goes first — the entries arrive newest-first, so truncating
+// the tail drops the least relevant run.
+func framePrior(rendered string) string {
+	text := strings.TrimSpace(rendered)
+	text = strings.ReplaceAll(text, "\x00", "")
+	if text == "" {
+		return ""
+	}
+	if len(text) > maxPriorBytes {
+		keep := maxPriorBytes - len(evidenceTruncation)
+		if keep < 0 {
+			keep = 0
+		}
+		text = text[:keep] + evidenceTruncation
+	}
+	return priorBegin + "\n" + text + "\n" + priorEnd
 }
 
 func framePlan(plan string) string {

--- a/internal/subagent/prompt_test.go
+++ b/internal/subagent/prompt_test.go
@@ -297,3 +297,53 @@ func TestRetryBlockDoesNotClaimTheAgentPushed(t *testing.T) {
 		t.Errorf("retry block should still say the previous attempt's work reached the branch:\n%s", p)
 	}
 }
+
+func TestBuildFixPromptIncludesPriorSessions(t *testing.T) {
+	p := BuildFixPrompt(FixRequest{
+		Repo: "svc", Reason: "fail", Evidence: map[string]any{"x": 1},
+		PriorSessions: "Fix 20260901T000000Z-svc (2h ago, run error)\n  agent said: bumped the pin\n",
+	})
+	if !strings.Contains(p, priorBegin) || !strings.Contains(p, priorEnd) {
+		t.Fatalf("missing prior-fix delimiters:\n%s", p)
+	}
+	if !strings.Contains(p, "bumped the pin") {
+		t.Fatalf("prior summary missing:\n%s", p)
+	}
+	// Trusted context, so outside the untrusted evidence block — and
+	// labeled as a record, since a past patch is not an instruction.
+	if strings.Index(p, priorBegin) > strings.Index(p, evidenceBegin) {
+		t.Fatal("prior sessions must sit before the untrusted evidence block")
+	}
+	if !strings.Contains(p, "records") {
+		t.Fatalf("prior block must be framed as records, not instructions:\n%s", p)
+	}
+}
+
+func TestBuildFixPromptNoPriorBlockWhenEmpty(t *testing.T) {
+	for _, in := range []string{"", "   \n\t "} {
+		p := BuildFixPrompt(FixRequest{Repo: "svc", Reason: "fail", PriorSessions: in})
+		if strings.Contains(p, priorBegin) {
+			t.Fatalf("empty prior sessions must emit no block (input %q)", in)
+		}
+	}
+}
+
+// History must never crowd out the failure that is red now, so the
+// block is capped well below the evidence budget.
+func TestBuildFixPromptCapsPriorSessions(t *testing.T) {
+	p := BuildFixPrompt(FixRequest{
+		Repo: "svc", Reason: "fail",
+		Evidence:      map[string]any{"log": "FAIL: TestFoo"},
+		PriorSessions: strings.Repeat("+old patch line\n", 4000),
+	})
+	block := p[strings.Index(p, priorBegin):strings.Index(p, priorEnd)]
+	if len(block) > maxPriorBytes+len(priorBegin)+len(evidenceTruncation)+2 {
+		t.Fatalf("prior block not capped: %d bytes", len(block))
+	}
+	if !strings.Contains(block, "truncated") {
+		t.Fatal("a clipped prior block must say it was clipped")
+	}
+	if !strings.Contains(p, "FAIL: TestFoo") {
+		t.Fatal("current evidence lost behind prior sessions")
+	}
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -92,6 +92,15 @@ func Config(cfg *config.Config) []Issue {
 			"agent.fix_attempts %d is negative; use 1 (single shot) or higher", cfg.Agent.FixAttempts)})
 	}
 
+	// Negative reads as "off" at runtime, which is probably what was
+	// meant, but a config that says -1 is more likely a typo than an
+	// intent to disable history.
+	if n := cfg.Agent.Sessions.PriorFixes; n != nil && *n < 0 {
+		issues = append(issues, Issue{Message: fmt.Sprintf(
+			"agent.sessions.prior_fixes %d is negative; use 0 to send no prior Fixes "+
+				"into the prompt, or a small positive count", *n)})
+	}
+
 	// A malformed committer identity is not caught until the coding
 	// agent's `git commit` fails inside a worktree, which reads as "the
 	// Fix produced nothing" rather than "the config is wrong".

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -168,7 +168,8 @@
         "enabled": { "type": "boolean" },
         "dir": { "type": "string" },
         "retain": { "type": "string" },
-        "max_file_bytes": { "type": "integer" }
+        "max_file_bytes": { "type": "integer" },
+        "prior_fixes": { "type": "integer", "minimum": 0, "description": "How many earlier finished Fixes for the same repo and source are summarized into the next Fix prompt. Default 2; 0 sends none." }
       }
     },
     "Server": {


### PR DESCRIPTION
## Summary

The last few finished Fix recordings for the same repo and source now reach the next Fix prompt, so a second Fix does not re-derive work the first one already tried.

## Test plan

- [x] `make test`
- [x] `make lint`
- [x] `make validate`
- [x] `make build`