### PR TITLE
Fix glibc image and clone fetch so Promote and Revert work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **The published image can run a copied `cursor-agent`.** Both Dockerfiles used Alpine, so a glibc Node binary and a `#!/usr/bin/env bash` launcher failed with `required file not found` (shop dogfood F1). The runtime image is now `node:22-bookworm-slim` with `bash`, `git`, and `ca-certificates`. Cursor is still not bundled: copy the host CLI onto PATH, or run Cursor's installer as root before `USER`.
+- **Promote and Revert can resolve `origin/main`.** Clones used `--depth 1 --single-branch`, so `git fetch origin main` updated `FETCH_HEAD` and never created `origin/main`. Revert died on `ambiguous argument 'origin/main'`, and Promote reported a non-fast-forward against a history that was a fast-forward on GitHub (shop dogfood F6). New clones fetch advertised heads. Existing shallow clones are unshallowed, their fetch refspec is widened to all heads, and fetch uses explicit `+refs/heads/<name>:refs/remotes/origin/<name>`.
+
 ## [0.0.1-beta.8] - 2026-09-09
 
 Prior Fix recordings in the next prompt, a stall watchdog, live Fix states in the console, and a CI scan fix so `main` stays green.

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -31,7 +31,11 @@ RUN mkdir -p internal/console/dist \
  && if [ -d /tmp/ui-dist ]; then cp -a /tmp/ui-dist/. internal/console/dist/; fi
 RUN CGO_ENABLED=0 GOOS=linux go build -o /out/xdlc ./cmd/xdlc-agent
 
-FROM node:22-alpine
+# Debian/glibc, not Alpine/musl: cursor-agent's bundled node is a glibc
+# ELF (`/lib64/ld-linux-x86-64.so.2`) and its launcher is
+# `#!/usr/bin/env bash`. Copying the host CLI into an Alpine image
+# failed with `required file not found` (shop dogfood F1).
+FROM node:22-bookworm-slim
 ARG KUBECTL_VERSION
 ARG ARGOCD_VERSION
 ARG CLAUDE_CODE_VERSION
@@ -39,28 +43,29 @@ ARG CODEX_CLI_VERSION
 ARG GEMINI_CLI_VERSION
 ARG TARGETARCH
 
-RUN apk add --no-cache git ca-certificates curl \
- && curl -fsSL -o /usr/local/bin/kubectl \
-      "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
- && chmod +x /usr/local/bin/kubectl \
- && curl -fsSL -o /usr/local/bin/argocd \
-      "https://github.com/argoproj/argo-cd/releases/download/v${ARGOCD_VERSION}/argocd-linux-${TARGETARCH}" \
- && chmod +x /usr/local/bin/argocd \
- && npm install -g \
-      "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
-      "@openai/codex@${CODEX_CLI_VERSION}" \
- && if [ -n "${GEMINI_CLI_VERSION}" ]; then \
-      npm install -g "@google/gemini-cli@${GEMINI_CLI_VERSION}"; \
-    fi \
- && npm cache clean --force
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl git bash \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL -o /usr/local/bin/kubectl \
+         "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
+    && chmod +x /usr/local/bin/kubectl \
+    && curl -fsSL -o /usr/local/bin/argocd \
+         "https://github.com/argoproj/argo-cd/releases/download/v${ARGOCD_VERSION}/argocd-linux-${TARGETARCH}" \
+    && chmod +x /usr/local/bin/argocd \
+    && npm install -g \
+         "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+         "@openai/codex@${CODEX_CLI_VERSION}" \
+    && if [ -n "${GEMINI_CLI_VERSION}" ]; then \
+         npm install -g "@google/gemini-cli@${GEMINI_CLI_VERSION}"; \
+       fi \
+    && npm cache clean --force
 
 # Cursor CLI (cursor-agent) isn't npm-installable — it ships via the
-# installer at https://cursor.com/install, which puts the binary in a
-# per-user home directory rather than a system path. If you need
-# agent.provider: cursor in this image, add that install step yourself
-# (pointing CURSOR_INSTALL_DIR, or its current equivalent, at
-# /usr/local/bin) and confirm it still matches Cursor's current docs —
-# left out here rather than guessed at.
+# installer at https://cursor.com/install. This image is glibc + bash so
+# that overlay (COPY the host CLI onto PATH, or run the installer as
+# root before USER) actually executes. Still left out of the default
+# image rather than pinning Cursor's installer in this Dockerfile.
 
 COPY --from=build /out/xdlc /usr/local/bin/xdlc
 
@@ -78,8 +83,9 @@ COPY --from=build /out/xdlc /usr/local/bin/xdlc
 RUN printf '[user]\n\tname = xdlc-agent\n\temail = xdlc-agent@users.noreply.github.com\n' > /etc/gitconfig
 
 # Match distroless/static nonroot (65532) used by example-service.
-RUN addgroup -g 65532 -S nonroot \
- && adduser -u 65532 -S -G nonroot nonroot \
+RUN groupadd --gid 65532 nonroot \
+ && useradd --uid 65532 --gid 65532 --home-dir /var/lib/xdlc-agent \
+      --no-create-home --shell /usr/sbin/nologin nonroot \
  && mkdir -p /var/lib/xdlc-agent \
  && chown -R nonroot:nonroot /var/lib/xdlc-agent
 

--- a/deploy/Dockerfile.release
+++ b/deploy/Dockerfile.release
@@ -10,7 +10,8 @@ ARG CODEX_CLI_VERSION=0.153.2
 # pinned to a version this repo has not tested.
 ARG GEMINI_CLI_VERSION=
 
-FROM node:22-alpine
+# Debian/glibc, not Alpine/musl: see deploy/Dockerfile (shop dogfood F1).
+FROM node:22-bookworm-slim
 ARG KUBECTL_VERSION
 ARG ARGOCD_VERSION
 ARG CLAUDE_CODE_VERSION
@@ -18,23 +19,25 @@ ARG CODEX_CLI_VERSION
 ARG GEMINI_CLI_VERSION
 ARG TARGETARCH
 
-RUN apk add --no-cache git ca-certificates curl \
- && curl -fsSL -o /usr/local/bin/kubectl \
-      "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
- && chmod +x /usr/local/bin/kubectl \
- && curl -fsSL -o /usr/local/bin/argocd \
-      "https://github.com/argoproj/argo-cd/releases/download/v${ARGOCD_VERSION}/argocd-linux-${TARGETARCH}" \
- && chmod +x /usr/local/bin/argocd \
- && npm install -g \
-      "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
-      "@openai/codex@${CODEX_CLI_VERSION}" \
- && if [ -n "${GEMINI_CLI_VERSION}" ]; then \
-      npm install -g "@google/gemini-cli@${GEMINI_CLI_VERSION}"; \
-    fi \
- && npm cache clean --force
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl git bash \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL -o /usr/local/bin/kubectl \
+         "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
+    && chmod +x /usr/local/bin/kubectl \
+    && curl -fsSL -o /usr/local/bin/argocd \
+         "https://github.com/argoproj/argo-cd/releases/download/v${ARGOCD_VERSION}/argocd-linux-${TARGETARCH}" \
+    && chmod +x /usr/local/bin/argocd \
+    && npm install -g \
+         "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+         "@openai/codex@${CODEX_CLI_VERSION}" \
+    && if [ -n "${GEMINI_CLI_VERSION}" ]; then \
+         npm install -g "@google/gemini-cli@${GEMINI_CLI_VERSION}"; \
+       fi \
+    && npm cache clean --force
 
-# Cursor CLI (cursor-agent) isn't npm-installable, see deploy/Dockerfile
-# for why it's left out of this image by default.
+# Cursor CLI (cursor-agent) isn't npm-installable, see deploy/Dockerfile.
 
 COPY xdlc /usr/local/bin/xdlc
 
@@ -52,8 +55,9 @@ COPY xdlc /usr/local/bin/xdlc
 RUN printf '[user]\n\tname = xdlc-agent\n\temail = xdlc-agent@users.noreply.github.com\n' > /etc/gitconfig
 
 # Match distroless/static nonroot (65532) used by example-service.
-RUN addgroup -g 65532 -S nonroot \
- && adduser -u 65532 -S -G nonroot nonroot \
+RUN groupadd --gid 65532 nonroot \
+ && useradd --uid 65532 --gid 65532 --home-dir /var/lib/xdlc-agent \
+      --no-create-home --shell /usr/sbin/nologin nonroot \
  && mkdir -p /var/lib/xdlc-agent \
  && chown -R nonroot:nonroot /var/lib/xdlc-agent
 

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -1068,8 +1068,8 @@ func (d *Dispatcher) revertInner(ctx context.Context, s orchestrator.Signal) err
 		return cmd.CombinedOutput()
 	}
 
-	if out, err := run("fetch", "origin", prod, dev); err != nil {
-		return fmt.Errorf("dispatch: revert: fetch: %w: %s", err, out)
+	if err := repos.FetchOriginHeads(ctx, dir, env, prod, dev); err != nil {
+		return fmt.Errorf("dispatch: revert: fetch: %w", err)
 	}
 	oldProd, err := run("rev-parse", "origin/"+prod)
 	if err != nil {

--- a/internal/promote/fastforward.go
+++ b/internal/promote/fastforward.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/xdlc-labs/xdlc-agent/internal/repos"
 )
 
 // CommitProdTag stages and commits the prod values file if dirty, then
@@ -70,10 +72,8 @@ func VerifyRemoteTip(ctx context.Context, repoDir string, env []string, branch, 
 	if !isHexSHA(wantSHA) {
 		return fmt.Errorf("promote: %q is not a git object name", wantSHA)
 	}
-	fetch := exec.CommandContext(ctx, "git", "-C", repoDir, "fetch", "origin", branch) //nolint:gosec // see FastForward
-	applyEnv(fetch, env)
-	if out, err := fetch.CombinedOutput(); err != nil {
-		return fmt.Errorf("promote: fetch %s: %w: %s", branch, err, out)
+	if err := repos.FetchOriginHeads(ctx, repoDir, env, branch); err != nil {
+		return fmt.Errorf("promote: fetch %s: %w", branch, err)
 	}
 	got, err := revParse(ctx, repoDir, env, "origin/"+branch)
 	if err != nil {
@@ -119,10 +119,8 @@ func FastForward(ctx context.Context, repoDir string, env []string, fromBranch, 
 	// (internal/repos.Manager.Dir), not external input; branch names
 	// come from config.yaml via repos.Manager, and gatedSHA is checked
 	// by isHexSHA before it reaches argv.
-	fetch := exec.CommandContext(ctx, "git", "-C", repoDir, "fetch", "origin", fromBranch, toBranch) //nolint:gosec
-	applyEnv(fetch, env)
-	if out, err := fetch.CombinedOutput(); err != nil {
-		return fmt.Errorf("promote: fetch: %w: %s", err, out)
+	if err := repos.FetchOriginHeads(ctx, repoDir, env, fromBranch, toBranch); err != nil {
+		return fmt.Errorf("promote: fetch: %w", err)
 	}
 
 	src := fromBranch
@@ -150,7 +148,11 @@ func FastForward(ctx context.Context, repoDir string, env []string, fromBranch, 
 	var stderr bytes.Buffer
 	push.Stderr = &stderr
 	if err := push.Run(); err != nil {
-		return fmt.Errorf("promote: push %s->%s not fast-forwardable: %w: %s", src, toBranch, err, stderr.String())
+		msg := stderr.String()
+		if strings.Contains(msg, "non-fast-forward") || strings.Contains(msg, "not fast-forward") {
+			return fmt.Errorf("promote: push %s->%s not fast-forwardable: %w: %s", src, toBranch, err, msg)
+		}
+		return fmt.Errorf("promote: push %s->%s: %w: %s", src, toBranch, err, msg)
 	}
 	return nil
 }

--- a/internal/promote/fastforward_test.go
+++ b/internal/promote/fastforward_test.go
@@ -8,6 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/xdlc-labs/xdlc-agent/internal/config"
+	"github.com/xdlc-labs/xdlc-agent/internal/repos"
 )
 
 func TestCarryProdTag(t *testing.T) {
@@ -264,4 +267,37 @@ func mustOutput(t *testing.T, dir string, args ...string) []byte {
 		t.Fatalf("git %v: %v: %s", args, err, out)
 	}
 	return out
+}
+
+// TestFastForwardFromShallowSingleBranch is the promote half of shop
+// F6: after EnsureCloned repairs the clone, develop must fast-forward
+// onto main.
+func TestFastForwardFromShallowSingleBranch(t *testing.T) {
+	bare, _, work := setupDevProd(t)
+	// Recreate work as the old daemon clone.
+	if err := os.RemoveAll(work); err != nil {
+		t.Fatal(err)
+	}
+	run := func(dir string, args ...string) {
+		t.Helper()
+		out, err := exec.CommandContext(context.Background(), "git", append([]string{"-C", dir}, args...)...).CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	run(filepath.Dir(bare), "clone", "--depth", "1", "--single-branch", "--branch", "develop", bare, work)
+
+	mgr := repos.NewManager("unused-root", []config.Repo{
+		{Name: "svc", GitHub: "org/svc", Dir: work, Branch: "develop", ProdBranch: "main"},
+	}, nil)
+	if err := mgr.EnsureCloned(context.Background(), "svc"); err != nil {
+		t.Fatalf("EnsureCloned: %v", err)
+	}
+	gated := revParseT(t, bare, "develop")
+	if err := FastForward(context.Background(), work, nil, "develop", "main", gated); err != nil {
+		t.Fatalf("FastForward: %v", err)
+	}
+	if got := revParseT(t, bare, "main"); got != gated {
+		t.Errorf("origin main = %s, want %s", got, gated)
+	}
 }

--- a/internal/repos/manager.go
+++ b/internal/repos/manager.go
@@ -287,11 +287,16 @@ func AuthEnv(token string) []string {
 // the directory doesn't exist, or fetches + hard-resets it to
 // origin/<branch> if it does. When HEAD already matches the remote tip
 // (ls-remote, not the local origin/<branch> tracking ref) and the
-// working tree is clean, the fetch is skipped (issue #17). Comparing
-// only the tracking ref would skip a Fix onto a stale commit after a
-// push the clone has not fetched yet. The hard reset still runs when
-// dirty or diverged: a plain `git fetch` alone would leave the working
-// tree on a stale commit.
+// working tree is clean, the fetch of that branch is skipped (issue
+// #17). Comparing only the tracking ref would skip a Fix onto a stale
+// commit after a push the clone has not fetched yet. The hard reset
+// still runs when dirty or diverged: a plain `git fetch` alone would
+// leave the working tree on a stale commit.
+//
+// The clone is a full fetch of advertised heads, not `--depth 1
+// --single-branch`. Promote and revert need origin/<prod> and enough
+// history to fast-forward onto it. Existing shallow single-branch
+// clones are unshallowed and have their fetch refspec widened.
 func (m *Manager) EnsureCloned(ctx context.Context, repo string) error {
 	r, ok := m.repos[repo]
 	if !ok {
@@ -303,10 +308,13 @@ func (m *Manager) EnsureCloned(ctx context.Context, repo string) error {
 	env := m.AuthEnv()
 
 	if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+		if err := m.prepareCloneForPromote(ctx, dir, env, branch, m.ProdBranch(repo)); err != nil {
+			return err
+		}
 		if m.localMatchesRemote(ctx, repo, dir, branch) {
 			return nil
 		}
-		if err := runGit(ctx, dir, env, "fetch", "origin", branch); err != nil {
+		if err := FetchOriginHeads(ctx, dir, env, branch, m.ProdBranch(repo)); err != nil {
 			return err
 		}
 		if err := runGit(ctx, dir, env, "checkout", branch); err != nil {
@@ -319,7 +327,82 @@ func (m *Manager) EnsureCloned(ctx context.Context, repo string) error {
 		return fmt.Errorf("repos: mkdir %s: %w", dir, err)
 	}
 	url := fmt.Sprintf("https://github.com/%s.git", r.GitHub)
-	return runGit(ctx, "", env, "clone", "--depth", "1", "--single-branch", "--branch", branch, url, dir)
+	// Full clone of the requested branch, all heads advertised. A
+	// `--depth 1 --single-branch` clone cannot resolve origin/<prod>
+	// and cannot prove a fast-forward onto main (shop dogfood F6).
+	if err := runGit(ctx, "", env, "clone", "--branch", branch, url, dir); err != nil {
+		return err
+	}
+	return m.prepareCloneForPromote(ctx, dir, env, branch, m.ProdBranch(repo))
+}
+
+// prepareCloneForPromote makes origin/<dev> and origin/<prod> resolvable
+// on an existing clone, including ones created with the old
+// `--depth 1 --single-branch` args. Config-only when the clone is
+// already complete so a synced EnsureCloned stays a skip-fetch.
+func (m *Manager) prepareCloneForPromote(ctx context.Context, dir string, env []string, dev, prod string) error {
+	if err := runGit(ctx, dir, env, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"); err != nil {
+		return err
+	}
+	shallow, err := gitOutput(ctx, dir, "rev-parse", "--is-shallow-repository")
+	if err == nil && shallow == "true" {
+		if err := runGit(ctx, dir, env, "fetch", "--unshallow", "origin"); err != nil {
+			return err
+		}
+	}
+	if _, err := gitOutput(ctx, dir, "rev-parse", "--verify", "refs/remotes/origin/"+prod); err == nil {
+		return nil
+	}
+	if !remoteHasBranch(ctx, dir, env, prod) {
+		return nil
+	}
+	return FetchOriginHeads(ctx, dir, env, dev, prod)
+}
+
+// FetchOriginHeads fetches each branch into refs/remotes/origin/<branch>
+// with an explicit refspec. `git fetch origin main` on a single-branch
+// clone updates FETCH_HEAD and does not create origin/main, which is
+// what revert's rev-parse and promote's fast-forward need.
+//
+// Branches are fetched one refspec at a time. A single `git fetch`
+// with two refspecs fails the whole command when the remote has no
+// prod branch, which is the default in tests and in a repo that has
+// not created main yet.
+func FetchOriginHeads(ctx context.Context, dir string, env []string, branches ...string) error {
+	seen := map[string]struct{}{}
+	for _, b := range branches {
+		b = strings.TrimSpace(b)
+		if b == "" {
+			continue
+		}
+		if _, ok := seen[b]; ok {
+			continue
+		}
+		seen[b] = struct{}{}
+		spec := "+refs/heads/" + b + ":refs/remotes/origin/" + b
+		if err := runGit(ctx, dir, env, "fetch", "origin", spec); err != nil {
+			if missingRemoteRef(err) {
+				continue
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func missingRemoteRef(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "couldn't find remote ref") || strings.Contains(s, "Couldn't find remote ref")
+}
+
+func remoteHasBranch(ctx context.Context, dir string, env []string, branch string) bool {
+	if branch == "" {
+		return false
+	}
+	return runGit(ctx, dir, env, "ls-remote", "--exit-code", "origin", "refs/heads/"+branch) == nil
 }
 
 // localMatchesRemote is true when HEAD is on branch, the tree is clean,

--- a/internal/repos/manager_test.go
+++ b/internal/repos/manager_test.go
@@ -324,3 +324,95 @@ func TestEnsureClonedFetchesWhenTrackingRefStale(t *testing.T) {
 		t.Errorf("HEAD %s != origin develop %s", head, want)
 	}
 }
+
+// TestEnsureClonedFetchesProdFromShallowSingleBranch is shop dogfood F6:
+// the old clone args left origin/main missing, so revert died on
+// rev-parse and promote reported a non-fast-forward against a history
+// that was a fast-forward on GitHub.
+func TestEnsureClonedFetchesProdFromShallowSingleBranch(t *testing.T) {
+	root := t.TempDir()
+	bareDir := filepath.Join(root, "origin.git")
+	seedDir := filepath.Join(root, "seed")
+	workDir := filepath.Join(root, "work")
+
+	gitCmdTest(t, root, "init", "--bare", bareDir)
+	gitCmdTest(t, root, "clone", bareDir, seedDir)
+	gitCmdTest(t, seedDir, "config", "user.email", "test@example.com")
+	gitCmdTest(t, seedDir, "config", "user.name", "test")
+	gitCmdTest(t, seedDir, "checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(seedDir, "app.txt"), []byte("prod\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmdTest(t, seedDir, "add", ".")
+	gitCmdTest(t, seedDir, "commit", "-m", "main")
+	gitCmdTest(t, seedDir, "push", "origin", "main")
+	gitCmdTest(t, seedDir, "checkout", "-b", "develop")
+	if err := os.WriteFile(filepath.Join(seedDir, "app.txt"), []byte("dev\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmdTest(t, seedDir, "add", ".")
+	gitCmdTest(t, seedDir, "commit", "-m", "develop")
+	gitCmdTest(t, seedDir, "push", "origin", "develop")
+	gitCmdTest(t, bareDir, "symbolic-ref", "HEAD", "refs/heads/develop")
+	gitCmdTest(t, root, "clone", "--depth", "1", "--single-branch", "--branch", "develop", bareDir, workDir)
+
+	if err := exec.CommandContext(context.Background(), "git", "-C", workDir, "rev-parse", "--verify", "refs/remotes/origin/main").Run(); err == nil {
+		t.Fatal("fixture still has origin/main; the old clone args should not")
+	}
+
+	mgr := NewManager("unused-root", []config.Repo{
+		{Name: "svc", GitHub: "org/svc", Dir: workDir, Branch: "develop", ProdBranch: "main"},
+	}, nil)
+	if err := mgr.EnsureCloned(context.Background(), "svc"); err != nil {
+		t.Fatalf("EnsureCloned: %v", err)
+	}
+	mainSHA := strings.TrimSpace(gitCmdTest(t, workDir, "rev-parse", "refs/remotes/origin/main"))
+	wantMain := strings.TrimSpace(gitCmdTest(t, bareDir, "rev-parse", "main"))
+	if mainSHA != wantMain {
+		t.Errorf("origin/main = %s, want %s", mainSHA, wantMain)
+	}
+	shallow := strings.TrimSpace(gitCmdTest(t, workDir, "rev-parse", "--is-shallow-repository"))
+	if shallow == "true" {
+		t.Error("clone still shallow after EnsureCloned")
+	}
+}
+
+// TestFetchOriginHeadsSkipsMissingProd is the default ProdBranch=main
+// case on a repo that only has develop: fetch must still update
+// origin/develop instead of failing the whole call.
+func TestFetchOriginHeadsSkipsMissingProd(t *testing.T) {
+	root := t.TempDir()
+	bareDir := filepath.Join(root, "origin.git")
+	seedDir := filepath.Join(root, "seed")
+	workDir := filepath.Join(root, "work")
+
+	gitCmdTest(t, root, "init", "--bare", bareDir)
+	gitCmdTest(t, root, "clone", bareDir, seedDir)
+	gitCmdTest(t, seedDir, "config", "user.email", "test@example.com")
+	gitCmdTest(t, seedDir, "config", "user.name", "test")
+	gitCmdTest(t, seedDir, "checkout", "-b", "develop")
+	if err := os.WriteFile(filepath.Join(seedDir, "app.txt"), []byte("v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmdTest(t, seedDir, "add", ".")
+	gitCmdTest(t, seedDir, "commit", "-m", "v1")
+	gitCmdTest(t, seedDir, "push", "origin", "develop")
+	gitCmdTest(t, bareDir, "symbolic-ref", "HEAD", "refs/heads/develop")
+	gitCmdTest(t, root, "clone", "--branch", "develop", bareDir, workDir)
+
+	if err := os.WriteFile(filepath.Join(seedDir, "app.txt"), []byte("v2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmdTest(t, seedDir, "add", ".")
+	gitCmdTest(t, seedDir, "commit", "-m", "v2")
+	gitCmdTest(t, seedDir, "push", "origin", "develop")
+
+	if err := FetchOriginHeads(context.Background(), workDir, nil, "develop", "main"); err != nil {
+		t.Fatalf("FetchOriginHeads: %v", err)
+	}
+	got := strings.TrimSpace(gitCmdTest(t, workDir, "rev-parse", "origin/develop"))
+	want := strings.TrimSpace(gitCmdTest(t, bareDir, "rev-parse", "develop"))
+	if got != want {
+		t.Errorf("origin/develop = %s, want %s", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Switch the published runtime image from Alpine/musl to Debian bookworm-slim with bash, so a copied `cursor-agent` can actually exec (shop dogfood F1). Cursor is still not bundled.
- Stop cloning with `--depth 1 --single-branch`. Fetch prod with an explicit refspec, unshallow leftover clones, and skip a missing prod branch so Revert can resolve `origin/main` and Promote no longer lies about a fast-forward (shop dogfood F6).

## Test plan
- [x] `gofmt` clean on changed Go files
- [x] `golangci-lint` on `internal/repos`, `internal/promote`, `internal/dispatch`
- [x] `go test -race` on those packages (`TestFixBudgetTimeout` skipped locally: known macOS hang)
- [ ] CI `make test` / `make lint` on Linux
- [ ] After merge, rebuild the shop agent from the published image on 192.168.178.175 and confirm **the agent** fast-forwards `develop` to `main` and Revert can `rev-parse origin/main`