### PR TITLE
Ship v0.0.1-beta.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+## [0.0.1-beta.9] - 2026-09-10
+
+A Debian image that can run a copied `cursor-agent`, and clones that Promote and Revert can actually fast-forward onto `main`.
+
+### Fixed
+
 - **The published image can run a copied `cursor-agent`.** Both Dockerfiles used Alpine, so a glibc Node binary and a `#!/usr/bin/env bash` launcher failed with `required file not found` (shop dogfood F1). The runtime image is now `node:22-bookworm-slim` with `bash`, `git`, and `ca-certificates`. Cursor is still not bundled: copy the host CLI onto PATH, or run Cursor's installer as root before `USER`.
 - **Promote and Revert can resolve `origin/main`.** Clones used `--depth 1 --single-branch`, so `git fetch origin main` updated `FETCH_HEAD` and never created `origin/main`. Revert died on `ambiguous argument 'origin/main'`, and Promote reported a non-fast-forward against a history that was a fast-forward on GitHub (shop dogfood F6). New clones fetch advertised heads. Existing shallow clones are unshallowed, their fetch refspec is widened to all heads, and fetch uses explicit `+refs/heads/<name>:refs/remotes/origin/<name>`.
 
@@ -372,6 +378,7 @@ First public beta of the open-source `xdlc-agent` daemon (MIT).
 - `claude.mode: sdk` reserved but unimplemented
 - AWS/EKS bootstrap not included (local Kind only)
 
+[0.0.1-beta.9]: https://github.com/xdlc-labs/xdlc-agent/releases/tag/v0.0.1-beta.9
 [0.0.1-beta.8]: https://github.com/xdlc-labs/xdlc-agent/releases/tag/v0.0.1-beta.8
 [0.0.1-beta.7]: https://github.com/xdlc-labs/xdlc-agent/releases/tag/v0.0.1-beta.7
 [0.0.1-beta.6]: https://github.com/xdlc-labs/xdlc-agent/releases/tag/v0.0.1-beta.6

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ API key at all — a stub agent that writes a canned patch, which exercises the 
 push and the gate re-check, and nothing about the agent.
 
 This is a public beta, so every release is a pre-release and GitHub's "latest" link skips
-them. Pin one with `XDLC_VERSION=v0.0.1-beta.8`, or pick a tag from
+them. Pin one with `XDLC_VERSION=v0.0.1-beta.9`, or pick a tag from
 [Releases](https://github.com/xdlc-labs/xdlc-agent/releases).
 
 The CLI is `xdlc`. The container image, Helm chart and this repository are `xdlc-agent`.
@@ -195,7 +195,7 @@ docker run --rm -p 8080:8080 \
   -v "$PWD/config.yaml:/etc/xdlc-agent/config.yaml:ro" \
   -e XDLC_API_TOKEN -e GITHUB_TOKEN -e GITHUB_WEBHOOK_SECRET \
   -e ANTHROPIC_API_KEY -e OPENAI_API_KEY -e CURSOR_API_KEY \
-  ghcr.io/xdlc-labs/xdlc-agent:0.0.1-beta.8 \
+  ghcr.io/xdlc-labs/xdlc-agent:0.0.1-beta.9 \
   daemon --config /etc/xdlc-agent/config.yaml
 ```
 </details>
@@ -207,7 +207,7 @@ Single replica: the audit DB is single-writer.
 
 ```bash
 helm install xdlc-agent deploy/helm/xdlc-agent \
-  --set image.tag=0.0.1-beta.8 \
+  --set image.tag=0.0.1-beta.9 \
   --set existingSecret=xdlc-agent-secrets \
   --set-file config=config.yaml
 ```

--- a/deploy/helm/xdlc-agent/Chart.yaml
+++ b/deploy/helm/xdlc-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: xdlc-agent
 description: xdlc orchestrator — CI Fix daemon; GitOps / prod gates optional
 type: application
-version: 0.0.1-beta.8
-appVersion: "0.0.1-beta.8"
+version: 0.0.1-beta.9
+appVersion: "0.0.1-beta.9"
 home: https://github.com/xdlc-labs/xdlc-agent
 sources:
   - https://github.com/xdlc-labs/xdlc-agent


### PR DESCRIPTION
## Summary
- Bump Helm `version` / `appVersion` and README install pins to `0.0.1-beta.9`.
- Move the glibc image and clone-fetch fixes out of Unreleased.

## Test plan
- [x] `./scripts/check-version-refs.sh`
- [x] `make validate`
- [ ] After merge, tag `v0.0.1-beta.9` (not `v1.0.0`) and wait for the release workflow
- [ ] Confirm GHCR package is public, then shop-retest Promote and Revert on `192.168.178.175` from this image